### PR TITLE
feat: add click-to-continue flow and improve practice mode UX

### DIFF
--- a/config/playwright.config.js
+++ b/config/playwright.config.js
@@ -13,8 +13,8 @@ export default defineConfig({
   use: {
     baseURL: 'http://localhost:5173',
     trace: 'on-first-retry',
-    screenshot: 'on', // Always take screenshots (changed from only-on-failure)
-    video: 'on', // Always record video (changed from retain-on-failure)
+    screenshot: 'only-on-failure', // Only take screenshots on failure for speed
+    video: 'retain-on-failure', // Only record video on failure for speed
   },
 
   projects: [

--- a/config/vite.config.js
+++ b/config/vite.config.js
@@ -35,8 +35,10 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './tests/vitest/setupTests.js',
-    css: true,
+    css: false, // Disable CSS processing for faster tests
     include: ['tests/vitest/**/*.test.{js,jsx,ts,tsx}'],
+    pool: 'threads', // Use worker threads for parallelism
+    testTimeout: 10000, // 10s default timeout
     exclude: [
       '**/node_modules/**',
       '**/dist/**',

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -2122,7 +2122,7 @@ const PracticePlayfield = ({ rows, selectedIdx, selectedSide, lastRecall, fullsc
             : `${p0Top.x},${p0Top.y} ${p100Top.x},${p100Top.y} ${boxLeft},${boxBottom} ${boxRight},${boxBottom}`;
           const line1End = activeGuideSide === 'L' ? boxLeft : boxRight;
           const line2End = activeGuideSide === 'L' ? boxRight : boxLeft;
-          const greenLayer = (
+          const guideLayer = (
             <svg className="absolute inset-0 pointer-events-none z-0" viewBox={`0 0 ${w} ${h}`}>
               {/* Shaded wedge between anchors and shot box - now a quadrilateral connecting to bottom corners */}
               <polygon

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1755,17 +1755,19 @@ const PracticePlayfield = ({ rows, selectedIdx, selectedSide, lastRecall, fullsc
       {!fullscreen && <h3 className={`font-medium mb-2 ${darkMode ? 'text-slate-200' : 'text-slate-900'}`}>Playfield</h3>}
       <div
         ref={canvasRef}
-        role="button"
-        tabIndex={0}
-        onClick={handlePlayfieldClick}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            handlePlayfieldClick();
-          } else if (e.key === ' ') {
-            e.preventDefault();
-            handlePlayfieldClick();
-          }
-        }}
+        {...(awaitingNextShot ? {
+          role: 'button',
+          tabIndex: 0,
+          onClick: handlePlayfieldClick,
+          onKeyDown: (e) => {
+            if (e.key === 'Enter') {
+              handlePlayfieldClick();
+            } else if (e.key === ' ') {
+              e.preventDefault();
+              handlePlayfieldClick();
+            }
+          },
+        } : {})}
         className={`relative border rounded-xl bg-gradient-to-b overflow-hidden ${awaitingNextShot ? 'cursor-pointer' : ''} ${darkMode ? 'from-slate-800 to-slate-900 border-slate-700' : 'from-slate-50 to-slate-100 border-slate-300'} ${fullscreen ? 'flex-1 min-h-0' : 'h-96'}`}
       >
         <PlayfieldScenery darkMode={darkMode} />
@@ -2944,7 +2946,7 @@ const App = () => {
     setPendingNextIdx(null);
     setPendingNextSide(null);
     setAwaitingNextShot(false);
-  }, [awaitingNextShot, pendingNextIdx, pendingNextSide, setSelectedIdx, setSelectedSide]);
+  }, [awaitingNextShot, pendingNextIdx, pendingNextSide]); // eslint-disable-line react-hooks/exhaustive-deps -- setState functions are stable
 
   const endSession = useCallback(() => {
     setFinalPhase(true);

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -2252,7 +2252,7 @@ const PracticePlayfield = ({ rows, selectedIdx, selectedSide, lastRecall, fullsc
               </svg>
             );
           }
-          return <>{greenLayer}{yellowLayer}{ballLayer}{staticBallLayer}</>;
+          return <>{guideLayer}{yellowLayer}{ballLayer}{staticBallLayer}</>;
         })() : null}
       </div>
     </div>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1759,7 +1759,10 @@ const PracticePlayfield = ({ rows, selectedIdx, selectedSide, lastRecall, fullsc
         tabIndex={0}
         onClick={handlePlayfieldClick}
         onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
+          if (e.key === 'Enter') {
+            handlePlayfieldClick();
+          } else if (e.key === ' ') {
+            e.preventDefault();
             handlePlayfieldClick();
           }
         }}

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -173,15 +173,27 @@ test.describe('Full Practice Workflow with Example Shots', () => {
     // Verify feedback is shown
     await expect(page.getByText(/last shot/i)).toBeVisible();
 
+    // Click playfield to advance to next shot (click-to-continue flow)
+    await page.locator('.relative.border.rounded-xl').first().click();
+    await page.waitForTimeout(500);
+
     // Test Case 2: Guess value 55
     await page.getByRole('button', { name: 'Recall 55' }).click();
     await page.waitForTimeout(1000);
     await page.screenshot({ path: 'test-results/workflow-10-guess-2-result.png', fullPage: true });
 
+    // Click playfield to advance to next shot
+    await page.locator('.relative.border.rounded-xl').first().click();
+    await page.waitForTimeout(500);
+
     // Test Case 3: Guess value 70
     await page.getByRole('button', { name: 'Recall 70' }).click();
     await page.waitForTimeout(1000);
     await page.screenshot({ path: 'test-results/workflow-11-guess-3-result.png', fullPage: true });
+
+    // Click playfield to advance to next shot
+    await page.locator('.relative.border.rounded-xl').first().click();
+    await page.waitForTimeout(500);
 
     // Test Case 4: Guess value 20
     await page.getByRole('button', { name: 'Recall 20' }).click();

--- a/tests/vitest/app-click-to-continue-coverage.test.jsx
+++ b/tests/vitest/app-click-to-continue-coverage.test.jsx
@@ -1,0 +1,609 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+import App from '../../src/app.jsx';
+
+const PLAYFIELD_SELECTOR = '.relative.border.rounded-xl';
+
+async function setupAndGoToPractice(user) {
+  render(<App />);
+
+  await waitFor(() => {
+    expect(screen.getByText(/setup shots/i)).toBeInTheDocument();
+  });
+
+  // Load example shots
+  const exampleButton = screen.getByRole('button', { name: /load example shots/i });
+  await user.click(exampleButton);
+
+  await waitFor(() => {
+    expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+
+  // Navigate to Practice mode
+  const practiceButton = screen.getAllByRole('button').find(btn =>
+    btn.textContent === 'Practice' && !btn.disabled,
+  );
+
+  if (practiceButton) {
+    await user.click(practiceButton);
+
+    // Wait for practice mode UI to load
+    await waitFor(() => {
+      expect(screen.queryByText(/setup shots/i)).not.toBeInTheDocument();
+    }, { timeout: 3000 });
+  }
+}
+
+describe('App - Click-to-Continue Coverage Tests', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should complete ball animation naturally and render static ball', async () => {
+    vi.useRealTimers(); // Use real timers for this test
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess to trigger animation
+    const recallButton = screen.getByRole('button', { name: /recall 50/i });
+    await user.click(recallButton);
+
+    // Wait for animation to complete naturally (travel + shake = ~800-900ms)
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /recall 50/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Wait for the full animation duration (500ms travel + up to 600ms shake)
+    await new Promise(resolve => setTimeout(resolve, 1500));
+
+    // Check for SVG elements in the playfield
+    await waitFor(() => {
+      const svgs = document.querySelectorAll('svg');
+      expect(svgs.length).toBeGreaterThan(0);
+    }, { timeout: 2000 });
+
+    // Check for circle elements (ball) 
+    const circles = document.querySelectorAll('circle');
+    expect(circles.length).toBeGreaterThan(0);
+  }, 25000);
+
+  it('should render static ball layer with correct SVG elements when awaiting', async () => {
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /recall 45/i });
+    await user.click(recallButton);
+
+    // Wait for awaiting state and animation to complete
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /recall 45/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Wait for animation to complete fully
+    await new Promise(resolve => setTimeout(resolve, 1800));
+
+    // Verify SVG elements are present (circles for ball)
+    await waitFor(() => {
+      // Check for circles (ball)
+      const circles = document.querySelectorAll('circle');
+      expect(circles.length).toBeGreaterThan(0);
+    }, { timeout: 3000 });
+  }, 25000);
+
+  it('should clear static ball when user clicks to continue', async () => {
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /recall 55/i });
+    await user.click(recallButton);
+
+    // Wait for awaiting state
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /recall 55/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Wait for animation to complete
+    await new Promise(resolve => setTimeout(resolve, 1800));
+
+    // Verify static ball exists
+    await waitFor(() => {
+      const circles = document.querySelectorAll('circle');
+      expect(circles.length).toBeGreaterThan(0);
+    }, { timeout: 2000 });
+
+    // Click playfield to advance
+    const playfield = document.querySelector(PLAYFIELD_SELECTOR);
+    if (playfield) {
+      await user.click(playfield);
+
+      // Wait for state to update
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /recall 55/i });
+        expect(btn).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 25000);
+
+  it('should show severity-colored guide when awaiting next shot with feedback', async () => {
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess that will have some error (severity)
+    const recallButton = screen.getByRole('button', { name: /recall 75/i });
+    await user.click(recallButton);
+
+    // Wait for awaiting state
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /recall 75/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Wait for animation to complete and feedback to show
+    await new Promise(resolve => setTimeout(resolve, 1800));
+
+    // Verify guide lines with stroke are present
+    await waitFor(() => {
+      const lines = document.querySelectorAll('line');
+      expect(lines.length).toBeGreaterThan(0);
+    }, { timeout: 2000 });
+  }, 25000);
+
+  it('should apply pending shot in random mode after click to continue', async () => {
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Switch to random mode
+    const allButtons = screen.getAllByRole('button');
+    const randomButton = allButtons.find(btn => btn.textContent === 'Random');
+    if (randomButton) {
+      await user.click(randomButton);
+    }
+
+    // Make first guess
+    const recallButton = screen.getByRole('button', { name: /recall 50/i });
+    await user.click(recallButton);
+
+    // Wait for awaiting state
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /recall 50/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Wait for animation
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    // Click playfield to apply pending next shot
+    const playfield = document.querySelector(PLAYFIELD_SELECTOR);
+    if (playfield) {
+      await user.click(playfield);
+
+      // Buttons should be enabled again
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /recall 50/i });
+        expect(btn).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 25000);
+
+  it('should keep same shot in manual mode after click to continue', async () => {
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Ensure we're in manual mode
+    const allButtons = screen.getAllByRole('button');
+    const manualButton = allButtons.find(btn => btn.textContent === 'Manual');
+    if (manualButton) {
+      await user.click(manualButton);
+    }
+
+    // Make guess
+    const recallButton = screen.getByRole('button', { name: /recall 60/i });
+    await user.click(recallButton);
+
+    // Wait for awaiting state
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /recall 60/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Click playfield
+    const playfield = document.querySelector(PLAYFIELD_SELECTOR);
+    if (playfield) {
+      await user.click(playfield);
+
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /recall 60/i });
+        expect(btn).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 25000);
+
+  it('should not advance if not awaiting next shot', async () => {
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Find playfield and try to click it before making any guess
+    const playfield = document.querySelector(PLAYFIELD_SELECTOR);
+    
+    // Click playfield - should not cause any issues since we're not awaiting
+    if (playfield) {
+      await user.click(playfield);
+    }
+
+    // Buttons should still be enabled (nothing should have changed)
+    const recallButton = screen.getByRole('button', { name: /recall 50/i });
+    expect(recallButton).not.toBeDisabled();
+  }, 15000);
+
+  it('should handle Enter key on playfield when awaiting', async () => {
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /recall 65/i });
+    await user.click(recallButton);
+
+    // Wait for awaiting state
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /recall 65/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Wait for animation
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    // Find playfield with role=button
+    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    if (playfield) {
+      playfield.focus();
+      await user.keyboard('{Enter}');
+
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /recall 65/i });
+        expect(btn).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 20000);
+
+  it('should handle Space key with preventDefault on playfield when awaiting', async () => {
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /recall 70/i });
+    await user.click(recallButton);
+
+    // Wait for awaiting state
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /recall 70/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Wait for animation
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    // Find playfield with role=button and press Space
+    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    if (playfield) {
+      playfield.focus();
+      await user.keyboard(' ');
+
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /recall 70/i });
+        expect(btn).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 20000);
+
+  it('should not have role=button on playfield when not awaiting', async () => {
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Before any guess, playfield should not have role=button
+    const playfieldWithRole = document.querySelector('[role="button"][tabindex="0"]');
+    expect(playfieldWithRole).toBeNull();
+  }, 15000);
+});
+
+describe('App - Reset to Defaults Button Coverage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  async function openAdvancedOptions(user) {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/setup shots/i)).toBeInTheDocument();
+    });
+
+    // Load example shots
+    const exampleButton = screen.getByRole('button', { name: /load example shots/i });
+    await user.click(exampleButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+
+    // Find the Advanced button (look for button with gear icon or specific style)
+    const buttons = screen.getAllByRole('button');
+    const advancedButton = buttons.find(btn => {
+      const title = btn.getAttribute('title');
+      return title && title.toLowerCase().includes('advanced');
+    });
+
+    if (advancedButton) {
+      await user.click(advancedButton);
+      
+      // Wait for advanced options to appear
+      await waitFor(() => {
+        expect(screen.getByText(/reset to defaults/i)).toBeInTheDocument();
+      }, { timeout: 2000 });
+      return true;
+    }
+    return false;
+  }
+
+  it('should reset advanced settings when clicking reset button', async () => {
+    const user = userEvent.setup();
+    const opened = await openAdvancedOptions(user);
+
+    if (opened) {
+      // Find and click reset button
+      const resetButton = screen.getByRole('button', { name: /reset to defaults/i });
+      await user.click(resetButton);
+
+      // Just verify the click happened without errors and button exists
+      expect(resetButton).toBeInTheDocument();
+    }
+  }, 15000);
+
+  it('should have reset button in advanced options dialog', async () => {
+    const user = userEvent.setup();
+    const opened = await openAdvancedOptions(user);
+
+    if (opened) {
+      const resetButton = screen.getByRole('button', { name: /reset to defaults/i });
+      expect(resetButton).toBeInTheDocument();
+      expect(resetButton).toHaveAttribute('title', 'Reset all advanced settings to their default values');
+    }
+  }, 15000);
+});
+
+describe('App - Ball Animation Skip and Complete Coverage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should save final ball position when skipping animation with Escape', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /recall 50/i });
+    await user.click(recallButton);
+
+    // Immediately skip with Escape
+    await user.keyboard('{Escape}');
+
+    // Should be in awaiting state with static ball shown
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /recall 50/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 2000 });
+
+    // Check for circle elements (static ball)
+    await waitFor(() => {
+      const circles = document.querySelectorAll('circle');
+      expect(circles.length).toBeGreaterThan(0);
+    }, { timeout: 2000 });
+  }, 15000);
+
+  it('should save final ball position when skipping animation with Enter', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /recall 55/i });
+    await user.click(recallButton);
+
+    // Skip with Enter
+    await user.keyboard('{Enter}');
+
+    // Should be in awaiting state
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /recall 55/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 2000 });
+  }, 15000);
+
+  it('should save final ball position when skipping animation with Space', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /recall 60/i });
+    await user.click(recallButton);
+
+    // Skip with Space
+    await user.keyboard(' ');
+
+    // Should be in awaiting state
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /recall 60/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 2000 });
+  }, 15000);
+});
+
+describe('App - Fullscreen Click-to-Continue Coverage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  async function setupFullscreenPractice(user) {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/setup shots/i)).toBeInTheDocument();
+    });
+
+    const exampleButton = screen.getByRole('button', { name: /load example shots/i });
+    await user.click(exampleButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+
+    const practiceButton = screen.getAllByRole('button').find(btn =>
+      btn.textContent === 'Practice' && !btn.disabled,
+    );
+
+    if (practiceButton) {
+      await user.click(practiceButton);
+      await waitFor(() => {
+        expect(screen.queryByText(/setup shots/i)).not.toBeInTheDocument();
+      }, { timeout: 3000 });
+    }
+
+    // Enter fullscreen mode
+    const fullscreenButton = screen.getByRole('button', { name: /fullscreen/i });
+    await user.click(fullscreenButton);
+
+    await waitFor(() => {
+      const exitButton = screen.queryByRole('button', { name: /exit/i });
+      expect(exitButton).toBeInTheDocument();
+    }, { timeout: 2000 });
+  }
+
+  it('should show static ball in fullscreen mode after animation completes', async () => {
+    const user = userEvent.setup();
+    await setupFullscreenPractice(user);
+
+    // Make a guess in fullscreen
+    const recallButtons = screen.getAllByRole('button', { name: /recall 50/i });
+    await user.click(recallButtons[0]);
+
+    // Wait for awaiting state
+    await waitFor(() => {
+      const btns = screen.getAllByRole('button', { name: /recall 50/i });
+      expect(btns[0]).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Wait for animation
+    await new Promise(resolve => setTimeout(resolve, 1500));
+
+    // Check for static ball
+    await waitFor(() => {
+      const circles = document.querySelectorAll('circle');
+      expect(circles.length).toBeGreaterThan(0);
+    }, { timeout: 2000 });
+  }, 25000);
+
+  it('should clear static ball in fullscreen when clicking playfield', async () => {
+    const user = userEvent.setup();
+    await setupFullscreenPractice(user);
+
+    // Make a guess
+    const recallButtons = screen.getAllByRole('button', { name: /recall 55/i });
+    await user.click(recallButtons[0]);
+
+    // Wait for awaiting state
+    await waitFor(() => {
+      const btns = screen.getAllByRole('button', { name: /recall 55/i });
+      expect(btns[0]).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Wait for animation
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    // Click playfield in fullscreen
+    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    if (playfield) {
+      await user.click(playfield);
+
+      // Buttons should be enabled again
+      await waitFor(() => {
+        const btns = screen.getAllByRole('button', { name: /recall 55/i });
+        expect(btns[0]).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 25000);
+
+  it('should disable Not Possible button in fullscreen when awaiting', async () => {
+    const user = userEvent.setup();
+    await setupFullscreenPractice(user);
+
+    // Make a guess
+    const recallButtons = screen.getAllByRole('button', { name: /recall 60/i });
+    await user.click(recallButtons[0]);
+
+    // Wait for awaiting state and check Not Possible button is disabled
+    await waitFor(() => {
+      const notPossibleButtons = screen.getAllByRole('button', { name: /not possible/i });
+      expect(notPossibleButtons[0]).toBeDisabled();
+    }, { timeout: 3000 });
+  }, 20000);
+});
+
+describe('App - DISABLED_CLASS Usage Coverage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should apply DISABLED_CLASS to recall buttons when awaiting', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /recall 50/i });
+    await user.click(recallButton);
+
+    // Wait for awaiting state
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /recall 50/i });
+      expect(btn).toBeDisabled();
+      // Check that it has the disabled styling
+      expect(btn.className).toContain('opacity-50');
+      expect(btn.className).toContain('cursor-not-allowed');
+    }, { timeout: 3000 });
+  }, 15000);
+
+  it('should apply DISABLED_CLASS to Not Possible button when awaiting', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /recall 50/i });
+    await user.click(recallButton);
+
+    // Wait for awaiting state and check Not Possible has disabled class
+    await waitFor(() => {
+      const notPossibleBtn = screen.getByRole('button', { name: /not possible/i });
+      expect(notPossibleBtn).toBeDisabled();
+      expect(notPossibleBtn.className).toContain('opacity-50');
+    }, { timeout: 3000 });
+  }, 15000);
+});

--- a/tests/vitest/app-click-to-continue-coverage.test.jsx
+++ b/tests/vitest/app-click-to-continue-coverage.test.jsx
@@ -71,7 +71,7 @@ describe('App - Click-to-Continue Coverage Tests', () => {
       expect(svgs.length).toBeGreaterThan(0);
     }, { timeout: 2000 });
 
-    // Check for circle elements (ball) 
+    // Check for circle elements (ball)
     const circles = document.querySelectorAll('circle');
     expect(circles.length).toBeGreaterThan(0);
   }, 25000);
@@ -243,7 +243,7 @@ describe('App - Click-to-Continue Coverage Tests', () => {
 
     // Find playfield and try to click it before making any guess
     const playfield = document.querySelector(PLAYFIELD_SELECTOR);
-    
+
     // Click playfield - should not cause any issues since we're not awaiting
     if (playfield) {
       await user.click(playfield);
@@ -356,7 +356,7 @@ describe('App - Reset to Defaults Button Coverage', () => {
 
     if (advancedButton) {
       await user.click(advancedButton);
-      
+
       // Wait for advanced options to appear
       await waitFor(() => {
         expect(screen.getByText(/reset to defaults/i)).toBeInTheDocument();

--- a/tests/vitest/app-click-to-continue-coverage.test.jsx
+++ b/tests/vitest/app-click-to-continue-coverage.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';

--- a/tests/vitest/app-click-to-continue.test.jsx
+++ b/tests/vitest/app-click-to-continue.test.jsx
@@ -1,51 +1,53 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 
 import App from '../../src/app.jsx';
+
+const PLAYFIELD_SELECTOR = '.relative.border.rounded-xl';
+
+async function setupAndGoToPractice(user) {
+  render(<App />);
+
+  await waitFor(() => {
+    expect(screen.getByText(/setup shots/i)).toBeInTheDocument();
+  });
+
+  // Load example shots
+  const exampleButton = screen.getByRole('button', { name: /load example shots/i });
+  await user.click(exampleButton);
+
+  await waitFor(() => {
+    expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+
+  // Navigate to Practice mode
+  const practiceButton = screen.getAllByRole('button').find(btn =>
+    btn.textContent === 'Practice' && !btn.disabled,
+  );
+
+  if (practiceButton) {
+    await user.click(practiceButton);
+
+    // Wait for practice mode UI to load
+    await waitFor(() => {
+      expect(screen.queryByText(/setup shots/i)).not.toBeInTheDocument();
+    }, { timeout: 3000 });
+  }
+}
 
 describe('App - Click-to-Continue Flow Tests', () => {
   beforeEach(() => {
     localStorage.clear();
   });
 
-  async function setupAndGoToPractice(user) {
-    render(<App />);
-
-    await waitFor(() => {
-      expect(screen.getByText(/setup shots/i)).toBeInTheDocument();
-    });
-
-    // Load example shots
-    const exampleButton = screen.getByRole('button', { name: /load example shots/i });
-    await user.click(exampleButton);
-
-    await waitFor(() => {
-      expect(screen.getByRole('table')).toBeInTheDocument();
-    });
-
-    // Navigate to Practice mode
-    const practiceButton = screen.getAllByRole('button').find(btn =>
-      btn.textContent === 'Practice' && !btn.disabled,
-    );
-
-    if (practiceButton) {
-      await user.click(practiceButton);
-
-      // Wait for practice mode UI to load
-      await waitFor(() => {
-        expect(screen.queryByText(/setup shots/i)).not.toBeInTheDocument();
-      }, { timeout: 3000 });
-    }
-  }
-
   it('should disable recall buttons after making a guess until clicking playfield', async () => {
     const user = userEvent.setup();
     await setupAndGoToPractice(user);
 
     // Find a recall button
-    const recallButton = screen.getByRole('button', { name: /Recall 50/i });
+    const recallButton = screen.getByRole('button', { name: /recall 50/i });
     expect(recallButton).not.toBeDisabled();
 
     // Make a guess
@@ -53,18 +55,18 @@ describe('App - Click-to-Continue Flow Tests', () => {
 
     // Wait for button to become disabled (awaiting next shot)
     await waitFor(() => {
-      const btn = screen.getByRole('button', { name: /Recall 50/i });
+      const btn = screen.getByRole('button', { name: /recall 50/i });
       expect(btn).toBeDisabled();
     }, { timeout: 3000 });
 
     // Find and click the playfield to advance to next shot
-    const playfield = document.querySelector('.relative.border.rounded-xl');
+    const playfield = document.querySelector(PLAYFIELD_SELECTOR);
     if (playfield) {
       await user.click(playfield);
 
       // Buttons should be enabled again
       await waitFor(() => {
-        const btn = screen.getByRole('button', { name: /Recall 50/i });
+        const btn = screen.getByRole('button', { name: /recall 50/i });
         expect(btn).not.toBeDisabled();
       }, { timeout: 3000 });
     }
@@ -75,23 +77,23 @@ describe('App - Click-to-Continue Flow Tests', () => {
     await setupAndGoToPractice(user);
 
     // Make a guess
-    const recallButton = screen.getByRole('button', { name: /Recall 55/i });
+    const recallButton = screen.getByRole('button', { name: /recall 55/i });
     await user.click(recallButton);
 
     // Wait for buttons to become disabled (awaiting next shot)
     await waitFor(() => {
-      const btn = screen.getByRole('button', { name: /Recall 55/i });
+      const btn = screen.getByRole('button', { name: /recall 55/i });
       expect(btn).toBeDisabled();
     }, { timeout: 3000 });
 
     // Click playfield to advance
-    const playfield = document.querySelector('.relative.border.rounded-xl');
+    const playfield = document.querySelector(PLAYFIELD_SELECTOR);
     if (playfield) {
       await user.click(playfield);
 
       // Wait a bit for state to update - buttons should be enabled again
       await waitFor(() => {
-        const recallBtn = screen.getByRole('button', { name: /Recall 55/i });
+        const recallBtn = screen.getByRole('button', { name: /recall 55/i });
         expect(recallBtn).not.toBeDisabled();
       }, { timeout: 3000 });
     }
@@ -102,12 +104,12 @@ describe('App - Click-to-Continue Flow Tests', () => {
     await setupAndGoToPractice(user);
 
     // Make a guess
-    const recallButton = screen.getByRole('button', { name: /Recall 60/i });
+    const recallButton = screen.getByRole('button', { name: /recall 60/i });
     await user.click(recallButton);
 
     // Wait for awaiting state
     await waitFor(() => {
-      const btn = screen.getByRole('button', { name: /Recall 60/i });
+      const btn = screen.getByRole('button', { name: /recall 60/i });
       expect(btn).toBeDisabled();
     }, { timeout: 3000 });
 
@@ -120,7 +122,7 @@ describe('App - Click-to-Continue Flow Tests', () => {
 
       // Buttons should be enabled again
       await waitFor(() => {
-        const btn = screen.getByRole('button', { name: /Recall 60/i });
+        const btn = screen.getByRole('button', { name: /recall 60/i });
         expect(btn).not.toBeDisabled();
       }, { timeout: 3000 });
     }
@@ -131,12 +133,12 @@ describe('App - Click-to-Continue Flow Tests', () => {
     await setupAndGoToPractice(user);
 
     // Make a guess
-    const recallButton = screen.getByRole('button', { name: /Recall 65/i });
+    const recallButton = screen.getByRole('button', { name: /recall 65/i });
     await user.click(recallButton);
 
     // Wait for awaiting state
     await waitFor(() => {
-      const btn = screen.getByRole('button', { name: /Recall 65/i });
+      const btn = screen.getByRole('button', { name: /recall 65/i });
       expect(btn).toBeDisabled();
     }, { timeout: 3000 });
 
@@ -148,7 +150,7 @@ describe('App - Click-to-Continue Flow Tests', () => {
 
       // Buttons should be enabled again
       await waitFor(() => {
-        const btn = screen.getByRole('button', { name: /Recall 65/i });
+        const btn = screen.getByRole('button', { name: /recall 65/i });
         expect(btn).not.toBeDisabled();
       }, { timeout: 3000 });
     }
@@ -166,23 +168,23 @@ describe('App - Click-to-Continue Flow Tests', () => {
     }
 
     // Make a guess
-    const recallButton = screen.getByRole('button', { name: /Recall 70/i });
+    const recallButton = screen.getByRole('button', { name: /recall 70/i });
     await user.click(recallButton);
 
     // Wait for awaiting state
     await waitFor(() => {
-      const btn = screen.getByRole('button', { name: /Recall 70/i });
+      const btn = screen.getByRole('button', { name: /recall 70/i });
       expect(btn).toBeDisabled();
     }, { timeout: 3000 });
 
     // Click playfield to advance
-    const playfield = document.querySelector('.relative.border.rounded-xl');
+    const playfield = document.querySelector(PLAYFIELD_SELECTOR);
     if (playfield) {
       await user.click(playfield);
 
       // Buttons should be enabled again (random shot applied)
       await waitFor(() => {
-        const btn = screen.getByRole('button', { name: /Recall 70/i });
+        const btn = screen.getByRole('button', { name: /recall 70/i });
         expect(btn).not.toBeDisabled();
       }, { timeout: 3000 });
     }
@@ -200,23 +202,23 @@ describe('App - Click-to-Continue Flow Tests', () => {
     }
 
     // Make a guess
-    const recallButton = screen.getByRole('button', { name: /Recall 45/i });
+    const recallButton = screen.getByRole('button', { name: /recall 45/i });
     await user.click(recallButton);
 
     // Wait for awaiting state
     await waitFor(() => {
-      const btn = screen.getByRole('button', { name: /Recall 45/i });
+      const btn = screen.getByRole('button', { name: /recall 45/i });
       expect(btn).toBeDisabled();
     }, { timeout: 3000 });
 
     // Click playfield to advance
-    const playfield = document.querySelector('.relative.border.rounded-xl');
+    const playfield = document.querySelector(PLAYFIELD_SELECTOR);
     if (playfield) {
       await user.click(playfield);
 
       // Buttons should be enabled again
       await waitFor(() => {
-        const btn = screen.getByRole('button', { name: /Recall 45/i });
+        const btn = screen.getByRole('button', { name: /recall 45/i });
         expect(btn).not.toBeDisabled();
       }, { timeout: 3000 });
     }
@@ -227,12 +229,12 @@ describe('App - Click-to-Continue Flow Tests', () => {
     await setupAndGoToPractice(user);
 
     // Make a guess with some error
-    const recallButton = screen.getByRole('button', { name: /Recall 80/i });
+    const recallButton = screen.getByRole('button', { name: /recall 80/i });
     await user.click(recallButton);
 
     // Wait for awaiting state and feedback
     await waitFor(() => {
-      const btn = screen.getByRole('button', { name: /Recall 80/i });
+      const btn = screen.getByRole('button', { name: /recall 80/i });
       expect(btn).toBeDisabled();
     }, { timeout: 3000 });
 
@@ -243,17 +245,17 @@ describe('App - Click-to-Continue Flow Tests', () => {
     }, { timeout: 2000 });
   }, 20000);
 
-  it('should display static ball at final position while awaiting next shot', async () => {
+  it('should show static ball at final position when awaiting next shot', async () => {
     const user = userEvent.setup();
     await setupAndGoToPractice(user);
 
     // Make a guess
-    const recallButton = screen.getByRole('button', { name: /Recall 35/i });
+    const recallButton = screen.getByRole('button', { name: /recall 35/i });
     await user.click(recallButton);
 
     // Wait for animation to complete and ball to be static
     await waitFor(() => {
-      const btn = screen.getByRole('button', { name: /Recall 35/i });
+      const btn = screen.getByRole('button', { name: /recall 35/i });
       expect(btn).toBeDisabled();
     }, { timeout: 3000 });
 
@@ -272,12 +274,12 @@ describe('App - Click-to-Continue Flow Tests', () => {
     await setupAndGoToPractice(user);
 
     // Make a guess
-    const recallButton = screen.getByRole('button', { name: /Recall 40/i });
+    const recallButton = screen.getByRole('button', { name: /recall 40/i });
     await user.click(recallButton);
 
     // Wait for awaiting state
     await waitFor(() => {
-      const btn = screen.getByRole('button', { name: /Recall 40/i });
+      const btn = screen.getByRole('button', { name: /recall 40/i });
       expect(btn).toBeDisabled();
     }, { timeout: 3000 });
 
@@ -285,13 +287,13 @@ describe('App - Click-to-Continue Flow Tests', () => {
     await new Promise(resolve => setTimeout(resolve, 1500));
 
     // Click playfield to advance
-    const playfield = document.querySelector('.relative.border.rounded-xl');
+    const playfield = document.querySelector(PLAYFIELD_SELECTOR);
     if (playfield) {
       await user.click(playfield);
 
       // Wait for state to update
       await waitFor(() => {
-        const btn = screen.getByRole('button', { name: /Recall 40/i });
+        const btn = screen.getByRole('button', { name: /recall 40/i });
         expect(btn).not.toBeDisabled();
       }, { timeout: 3000 });
     }
@@ -315,7 +317,7 @@ describe('App - Click-to-Continue Flow Tests', () => {
     }, { timeout: 3000 });
 
     // Click playfield to advance
-    const playfield = document.querySelector('.relative.border.rounded-xl');
+    const playfield = document.querySelector(PLAYFIELD_SELECTOR);
     if (playfield) {
       await user.click(playfield);
 
@@ -350,11 +352,11 @@ describe('App - Advanced Options Reset Button', () => {
 
     // Find the Advanced button (has a gear/cog icon, look for title or find button with specific text)
     // The Advanced options button is in setup mode, look for it
-    const advancedButton = screen.getAllByRole('button').find(btn => 
+    const advancedButton = screen.getAllByRole('button').find(btn =>
       btn.getAttribute('title')?.toLowerCase().includes('advanced') ||
       btn.textContent?.toLowerCase().includes('advanced'),
     );
-    
+
     if (advancedButton) {
       await user.click(advancedButton);
       await waitFor(() => {
@@ -368,7 +370,7 @@ describe('App - Advanced Options Reset Button', () => {
   it('should show reset button in advanced options dialog', async () => {
     const user = userEvent.setup();
     const opened = await openAdvancedOptionsFromSetup(user);
-    
+
     if (opened) {
       // Find and click reset button
       const resetButton = screen.getByRole('button', { name: /reset to defaults/i });
@@ -382,38 +384,12 @@ describe('App - Ball Animation Refs Pattern', () => {
     localStorage.clear();
   });
 
-  async function setupAndGoToPractice(user) {
-    render(<App />);
-
-    await waitFor(() => {
-      expect(screen.getByText(/setup shots/i)).toBeInTheDocument();
-    });
-
-    const exampleButton = screen.getByRole('button', { name: /load example shots/i });
-    await user.click(exampleButton);
-
-    await waitFor(() => {
-      expect(screen.getByRole('table')).toBeInTheDocument();
-    });
-
-    const practiceButton = screen.getAllByRole('button').find(btn =>
-      btn.textContent === 'Practice' && !btn.disabled,
-    );
-
-    if (practiceButton) {
-      await user.click(practiceButton);
-      await waitFor(() => {
-        expect(screen.queryByText(/setup shots/i)).not.toBeInTheDocument();
-      }, { timeout: 3000 });
-    }
-  }
-
   it('should trigger ball animation with refs pattern on recall attempt', async () => {
     const user = userEvent.setup();
     await setupAndGoToPractice(user);
 
     // Make a guess to trigger animation
-    const recallButton = screen.getByRole('button', { name: /Recall 50/i });
+    const recallButton = screen.getByRole('button', { name: /recall 50/i });
     await user.click(recallButton);
 
     // Animation should start - check for ball elements
@@ -429,12 +405,12 @@ describe('App - Ball Animation Refs Pattern', () => {
     await setupAndGoToPractice(user);
 
     // Make a guess
-    const recallButton = screen.getByRole('button', { name: /Recall 55/i });
+    const recallButton = screen.getByRole('button', { name: /recall 55/i });
     await user.click(recallButton);
 
     // Wait for buttons to be disabled (awaiting state)
     await waitFor(() => {
-      const btn = screen.getByRole('button', { name: /Recall 55/i });
+      const btn = screen.getByRole('button', { name: /recall 55/i });
       expect(btn).toBeDisabled();
     }, { timeout: 3000 });
   }, 15000);
@@ -444,7 +420,7 @@ describe('App - Ball Animation Refs Pattern', () => {
     await setupAndGoToPractice(user);
 
     // Make a guess
-    const recallButton = screen.getByRole('button', { name: /Recall 60/i });
+    const recallButton = screen.getByRole('button', { name: /recall 60/i });
     await user.click(recallButton);
 
     // Immediately press Escape to skip
@@ -452,7 +428,7 @@ describe('App - Ball Animation Refs Pattern', () => {
 
     // Should be in awaiting state (buttons disabled)
     await waitFor(() => {
-      const btn = screen.getByRole('button', { name: /Recall 60/i });
+      const btn = screen.getByRole('button', { name: /recall 60/i });
       expect(btn).toBeDisabled();
     }, { timeout: 2000 });
   }, 15000);
@@ -462,7 +438,7 @@ describe('App - Ball Animation Refs Pattern', () => {
     await setupAndGoToPractice(user);
 
     // Make a guess
-    const recallButton = screen.getByRole('button', { name: /Recall 65/i });
+    const recallButton = screen.getByRole('button', { name: /recall 65/i });
     await user.click(recallButton);
 
     // Press Enter to skip
@@ -470,7 +446,7 @@ describe('App - Ball Animation Refs Pattern', () => {
 
     // Should be in awaiting state
     await waitFor(() => {
-      const btn = screen.getByRole('button', { name: /Recall 65/i });
+      const btn = screen.getByRole('button', { name: /recall 65/i });
       expect(btn).toBeDisabled();
     }, { timeout: 2000 });
   }, 15000);
@@ -480,7 +456,7 @@ describe('App - Ball Animation Refs Pattern', () => {
     await setupAndGoToPractice(user);
 
     // Make a guess
-    const recallButton = screen.getByRole('button', { name: /Recall 70/i });
+    const recallButton = screen.getByRole('button', { name: /recall 70/i });
     await user.click(recallButton);
 
     // Press Space to skip
@@ -488,7 +464,7 @@ describe('App - Ball Animation Refs Pattern', () => {
 
     // Should be in awaiting state
     await waitFor(() => {
-      const btn = screen.getByRole('button', { name: /Recall 70/i });
+      const btn = screen.getByRole('button', { name: /recall 70/i });
       expect(btn).toBeDisabled();
     }, { timeout: 2000 });
   }, 15000);
@@ -540,7 +516,7 @@ describe('App - Fullscreen Click-to-Continue Flow', () => {
     await setupFullscreenPractice(user);
 
     // Find recall buttons in fullscreen (there will be duplicates, use getAllBy)
-    const recallButtons = screen.getAllByRole('button', { name: /Recall 50/i });
+    const recallButtons = screen.getAllByRole('button', { name: /recall 50/i });
     expect(recallButtons[0]).not.toBeDisabled();
 
     // Make a guess using the first one
@@ -548,7 +524,7 @@ describe('App - Fullscreen Click-to-Continue Flow', () => {
 
     // Wait for buttons to become disabled
     await waitFor(() => {
-      const btns = screen.getAllByRole('button', { name: /Recall 50/i });
+      const btns = screen.getAllByRole('button', { name: /recall 50/i });
       expect(btns[0]).toBeDisabled();
     }, { timeout: 3000 });
   }, 20000);
@@ -558,12 +534,12 @@ describe('App - Fullscreen Click-to-Continue Flow', () => {
     await setupFullscreenPractice(user);
 
     // Make a guess
-    const recallButtons = screen.getAllByRole('button', { name: /Recall 55/i });
+    const recallButtons = screen.getAllByRole('button', { name: /recall 55/i });
     await user.click(recallButtons[0]);
 
     // Wait for awaiting state
     await waitFor(() => {
-      const btns = screen.getAllByRole('button', { name: /Recall 55/i });
+      const btns = screen.getAllByRole('button', { name: /recall 55/i });
       expect(btns[0]).toBeDisabled();
     }, { timeout: 3000 });
 
@@ -574,7 +550,7 @@ describe('App - Fullscreen Click-to-Continue Flow', () => {
 
       // Buttons should be enabled again
       await waitFor(() => {
-        const btns = screen.getAllByRole('button', { name: /Recall 55/i });
+        const btns = screen.getAllByRole('button', { name: /recall 55/i });
         expect(btns[0]).not.toBeDisabled();
       }, { timeout: 3000 });
     }

--- a/tests/vitest/app-click-to-continue.test.jsx
+++ b/tests/vitest/app-click-to-continue.test.jsx
@@ -1,0 +1,582 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import App from '../../src/app.jsx';
+
+describe('App - Click-to-Continue Flow Tests', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  async function setupAndGoToPractice(user) {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/setup shots/i)).toBeInTheDocument();
+    });
+
+    // Load example shots
+    const exampleButton = screen.getByRole('button', { name: /load example shots/i });
+    await user.click(exampleButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+
+    // Navigate to Practice mode
+    const practiceButton = screen.getAllByRole('button').find(btn =>
+      btn.textContent === 'Practice' && !btn.disabled,
+    );
+
+    if (practiceButton) {
+      await user.click(practiceButton);
+
+      // Wait for practice mode UI to load
+      await waitFor(() => {
+        expect(screen.queryByText(/setup shots/i)).not.toBeInTheDocument();
+      }, { timeout: 3000 });
+    }
+  }
+
+  it('should disable recall buttons after making a guess until clicking playfield', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Find a recall button
+    const recallButton = screen.getByRole('button', { name: /Recall 50/i });
+    expect(recallButton).not.toBeDisabled();
+
+    // Make a guess
+    await user.click(recallButton);
+
+    // Wait for button to become disabled (awaiting next shot)
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /Recall 50/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Find and click the playfield to advance to next shot
+    const playfield = document.querySelector('.relative.border.rounded-xl');
+    if (playfield) {
+      await user.click(playfield);
+
+      // Buttons should be enabled again
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /Recall 50/i });
+        expect(btn).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 20000);
+
+  it('should show disabled state when awaiting next shot', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /Recall 55/i });
+    await user.click(recallButton);
+
+    // Wait for buttons to become disabled (awaiting next shot)
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /Recall 55/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Click playfield to advance
+    const playfield = document.querySelector('.relative.border.rounded-xl');
+    if (playfield) {
+      await user.click(playfield);
+
+      // Wait a bit for state to update - buttons should be enabled again
+      await waitFor(() => {
+        const recallBtn = screen.getByRole('button', { name: /Recall 55/i });
+        expect(recallBtn).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 20000);
+
+  it('should handle keyboard navigation on playfield to advance to next shot', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /Recall 60/i });
+    await user.click(recallButton);
+
+    // Wait for awaiting state
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /Recall 60/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Find playfield and trigger keyboard event
+    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    if (playfield) {
+      // Focus the playfield and press Enter
+      playfield.focus();
+      await user.keyboard('{Enter}');
+
+      // Buttons should be enabled again
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /Recall 60/i });
+        expect(btn).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 20000);
+
+  it('should handle Space key on playfield to advance to next shot', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /Recall 65/i });
+    await user.click(recallButton);
+
+    // Wait for awaiting state
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /Recall 65/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Find playfield and trigger Space key
+    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    if (playfield) {
+      playfield.focus();
+      await user.keyboard(' ');
+
+      // Buttons should be enabled again
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /Recall 65/i });
+        expect(btn).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 20000);
+
+  it('should store pending next shot in random mode and apply when clicking to continue', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Switch to random mode
+    const allButtons = screen.getAllByRole('button');
+    const randomButton = allButtons.find(btn => btn.textContent === 'Random');
+    if (randomButton) {
+      await user.click(randomButton);
+    }
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /Recall 70/i });
+    await user.click(recallButton);
+
+    // Wait for awaiting state
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /Recall 70/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Click playfield to advance
+    const playfield = document.querySelector('.relative.border.rounded-xl');
+    if (playfield) {
+      await user.click(playfield);
+
+      // Buttons should be enabled again (random shot applied)
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /Recall 70/i });
+        expect(btn).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 20000);
+
+  it('should keep the same shot/side in manual mode after clicking to continue', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Ensure we're in manual mode
+    const allButtons = screen.getAllByRole('button');
+    const manualButton = allButtons.find(btn => btn.textContent === 'Manual');
+    if (manualButton) {
+      await user.click(manualButton);
+    }
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /Recall 45/i });
+    await user.click(recallButton);
+
+    // Wait for awaiting state
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /Recall 45/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Click playfield to advance
+    const playfield = document.querySelector('.relative.border.rounded-xl');
+    if (playfield) {
+      await user.click(playfield);
+
+      // Buttons should be enabled again
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /Recall 45/i });
+        expect(btn).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 20000);
+
+  it('should show guide lines with severity color when awaiting next shot', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess with some error
+    const recallButton = screen.getByRole('button', { name: /Recall 80/i });
+    await user.click(recallButton);
+
+    // Wait for awaiting state and feedback
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /Recall 80/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Check that SVG elements exist for the guide
+    await waitFor(() => {
+      const svgElements = document.querySelectorAll('svg');
+      expect(svgElements.length).toBeGreaterThan(0);
+    }, { timeout: 2000 });
+  }, 20000);
+
+  it('should display static ball at final position while awaiting next shot', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /Recall 35/i });
+    await user.click(recallButton);
+
+    // Wait for animation to complete and ball to be static
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /Recall 35/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Wait for animation and static ball
+    await new Promise(resolve => setTimeout(resolve, 1500));
+
+    // Check for circle elements (ball)
+    await waitFor(() => {
+      const circles = document.querySelectorAll('circle');
+      expect(circles.length).toBeGreaterThan(0);
+    }, { timeout: 2000 });
+  }, 20000);
+
+  it('should clear final ball position when advancing to next shot', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /Recall 40/i });
+    await user.click(recallButton);
+
+    // Wait for awaiting state
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /Recall 40/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Wait for animation
+    await new Promise(resolve => setTimeout(resolve, 1500));
+
+    // Click playfield to advance
+    const playfield = document.querySelector('.relative.border.rounded-xl');
+    if (playfield) {
+      await user.click(playfield);
+
+      // Wait for state to update
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /Recall 40/i });
+        expect(btn).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 20000);
+
+  it('should handle Not Possible button with click-to-continue flow', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Find the "Not Possible" button
+    const notPossibleButton = screen.getByRole('button', { name: /not possible/i });
+    expect(notPossibleButton).not.toBeDisabled();
+
+    // Click Not Possible
+    await user.click(notPossibleButton);
+
+    // Button should be disabled after guess
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /not possible/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Click playfield to advance
+    const playfield = document.querySelector('.relative.border.rounded-xl');
+    if (playfield) {
+      await user.click(playfield);
+
+      // Button should be enabled again
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /not possible/i });
+        expect(btn).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 20000);
+});
+
+describe('App - Advanced Options Reset Button', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  async function openAdvancedOptionsFromSetup(user) {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/setup shots/i)).toBeInTheDocument();
+    });
+
+    // Load example shots
+    const exampleButton = screen.getByRole('button', { name: /load example shots/i });
+    await user.click(exampleButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+
+    // Find the Advanced button (has a gear/cog icon, look for title or find button with specific text)
+    // The Advanced options button is in setup mode, look for it
+    const advancedButton = screen.getAllByRole('button').find(btn => 
+      btn.getAttribute('title')?.toLowerCase().includes('advanced') ||
+      btn.textContent?.toLowerCase().includes('advanced'),
+    );
+    
+    if (advancedButton) {
+      await user.click(advancedButton);
+      await waitFor(() => {
+        expect(screen.getByText(/reset to defaults/i)).toBeInTheDocument();
+      }, { timeout: 2000 });
+      return true;
+    }
+    return false;
+  }
+
+  it('should show reset button in advanced options dialog', async () => {
+    const user = userEvent.setup();
+    const opened = await openAdvancedOptionsFromSetup(user);
+    
+    if (opened) {
+      // Find and click reset button
+      const resetButton = screen.getByRole('button', { name: /reset to defaults/i });
+      expect(resetButton).toBeInTheDocument();
+    }
+  }, 15000);
+});
+
+describe('App - Ball Animation Refs Pattern', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  async function setupAndGoToPractice(user) {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/setup shots/i)).toBeInTheDocument();
+    });
+
+    const exampleButton = screen.getByRole('button', { name: /load example shots/i });
+    await user.click(exampleButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+
+    const practiceButton = screen.getAllByRole('button').find(btn =>
+      btn.textContent === 'Practice' && !btn.disabled,
+    );
+
+    if (practiceButton) {
+      await user.click(practiceButton);
+      await waitFor(() => {
+        expect(screen.queryByText(/setup shots/i)).not.toBeInTheDocument();
+      }, { timeout: 3000 });
+    }
+  }
+
+  it('should trigger ball animation with refs pattern on recall attempt', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess to trigger animation
+    const recallButton = screen.getByRole('button', { name: /Recall 50/i });
+    await user.click(recallButton);
+
+    // Animation should start - check for ball elements
+    await waitFor(() => {
+      // Look for any circle elements (ball)
+      const circles = document.querySelectorAll('circle');
+      expect(circles.length).toBeGreaterThan(0);
+    }, { timeout: 3000 });
+  }, 15000);
+
+  it('should transition to awaiting state after ball animation', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /Recall 55/i });
+    await user.click(recallButton);
+
+    // Wait for buttons to be disabled (awaiting state)
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /Recall 55/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+  }, 15000);
+
+  it('should skip ball animation with Escape key and transition to awaiting', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /Recall 60/i });
+    await user.click(recallButton);
+
+    // Immediately press Escape to skip
+    await user.keyboard('{Escape}');
+
+    // Should be in awaiting state (buttons disabled)
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /Recall 60/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 2000 });
+  }, 15000);
+
+  it('should skip ball animation with Enter key', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /Recall 65/i });
+    await user.click(recallButton);
+
+    // Press Enter to skip
+    await user.keyboard('{Enter}');
+
+    // Should be in awaiting state
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /Recall 65/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 2000 });
+  }, 15000);
+
+  it('should skip ball animation with Space key', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /Recall 70/i });
+    await user.click(recallButton);
+
+    // Press Space to skip
+    await user.keyboard(' ');
+
+    // Should be in awaiting state
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /Recall 70/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 2000 });
+  }, 15000);
+});
+
+describe('App - Fullscreen Click-to-Continue Flow', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  async function setupFullscreenPractice(user) {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/setup shots/i)).toBeInTheDocument();
+    });
+
+    const exampleButton = screen.getByRole('button', { name: /load example shots/i });
+    await user.click(exampleButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+
+    const practiceButton = screen.getAllByRole('button').find(btn =>
+      btn.textContent === 'Practice' && !btn.disabled,
+    );
+
+    if (practiceButton) {
+      await user.click(practiceButton);
+      await waitFor(() => {
+        expect(screen.queryByText(/setup shots/i)).not.toBeInTheDocument();
+      }, { timeout: 3000 });
+    }
+
+    // Enter fullscreen mode
+    const fullscreenButton = screen.getByRole('button', { name: /fullscreen/i });
+    await user.click(fullscreenButton);
+
+    await waitFor(() => {
+      // Fullscreen mode should be active
+      const exitButton = screen.queryByRole('button', { name: /exit/i });
+      expect(exitButton).toBeInTheDocument();
+    }, { timeout: 2000 });
+  }
+
+  it('should disable recall chips in fullscreen after making a guess', async () => {
+    const user = userEvent.setup();
+    await setupFullscreenPractice(user);
+
+    // Find recall buttons in fullscreen (there will be duplicates, use getAllBy)
+    const recallButtons = screen.getAllByRole('button', { name: /Recall 50/i });
+    expect(recallButtons[0]).not.toBeDisabled();
+
+    // Make a guess using the first one
+    await user.click(recallButtons[0]);
+
+    // Wait for buttons to become disabled
+    await waitFor(() => {
+      const btns = screen.getAllByRole('button', { name: /Recall 50/i });
+      expect(btns[0]).toBeDisabled();
+    }, { timeout: 3000 });
+  }, 20000);
+
+  it('should enable recall chips in fullscreen after clicking playfield', async () => {
+    const user = userEvent.setup();
+    await setupFullscreenPractice(user);
+
+    // Make a guess
+    const recallButtons = screen.getAllByRole('button', { name: /Recall 55/i });
+    await user.click(recallButtons[0]);
+
+    // Wait for awaiting state
+    await waitFor(() => {
+      const btns = screen.getAllByRole('button', { name: /Recall 55/i });
+      expect(btns[0]).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Find and click the playfield in fullscreen
+    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    if (playfield) {
+      await user.click(playfield);
+
+      // Buttons should be enabled again
+      await waitFor(() => {
+        const btns = screen.getAllByRole('button', { name: /Recall 55/i });
+        expect(btns[0]).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 20000);
+});

--- a/tests/vitest/app-patch-coverage.test.jsx
+++ b/tests/vitest/app-patch-coverage.test.jsx
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import App from '../../src/app.jsx';
 
 const PLAYFIELD_SELECTOR = '.relative.border.rounded-xl';
+const INTERACTIVE_PLAYFIELD_SELECTOR = '[role="button"][tabindex="0"]';
 
 async function setupAndGoToPractice(user) {
   render(<App />);
@@ -196,7 +197,7 @@ describe('App - Playfield Interaction Coverage', () => {
     }, { timeout: 3000 });
 
     // Find playfield and click it multiple times to exercise the callback
-    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    const playfield = document.querySelector(INTERACTIVE_PLAYFIELD_SELECTOR);
     if (playfield) {
       await user.click(playfield);
 
@@ -219,7 +220,7 @@ describe('App - Playfield Interaction Coverage', () => {
     }, { timeout: 3000 });
 
     // Test Enter key
-    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    const playfield = document.querySelector(INTERACTIVE_PLAYFIELD_SELECTOR);
     if (playfield) {
       playfield.focus();
       fireEvent.keyDown(playfield, { key: 'Enter' });
@@ -243,7 +244,7 @@ describe('App - Playfield Interaction Coverage', () => {
     }, { timeout: 3000 });
 
     // Test Space key
-    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    const playfield = document.querySelector(INTERACTIVE_PLAYFIELD_SELECTOR);
     if (playfield) {
       playfield.focus();
       fireEvent.keyDown(playfield, { key: ' ' });
@@ -325,9 +326,9 @@ describe('App - advanceToNextShot Callback Coverage', () => {
 
     // The advanceToNextShot callback should return early when awaitingNextShot is false
     // We can test this by attempting to interact with playfield before any guess
-    
+
     // Before making a guess, playfield shouldn't have role=button
-    const interactivePlayfield = document.querySelector('[role="button"][tabindex="0"]');
+    const interactivePlayfield = document.querySelector(INTERACTIVE_PLAYFIELD_SELECTOR);
     expect(interactivePlayfield).toBeNull();
 
     // Make a guess to trigger awaiting state
@@ -336,7 +337,7 @@ describe('App - advanceToNextShot Callback Coverage', () => {
 
     // Now playfield should be interactive
     await waitFor(() => {
-      const interactive = document.querySelector('[role="button"][tabindex="0"]');
+      const interactive = document.querySelector(INTERACTIVE_PLAYFIELD_SELECTOR);
       expect(interactive).not.toBeNull();
     }, { timeout: 3000 });
   }, 15000);
@@ -359,7 +360,7 @@ describe('App - advanceToNextShot Callback Coverage', () => {
     }, { timeout: 3000 });
 
     // Click playfield to apply pending values
-    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    const playfield = document.querySelector(INTERACTIVE_PLAYFIELD_SELECTOR);
     if (playfield) {
       await user.click(playfield);
 
@@ -430,7 +431,7 @@ describe('App - Clear Final Ball Position Coverage', () => {
     await new Promise(resolve => setTimeout(resolve, 1500));
 
     // Click playfield to clear awaiting state (which should clear final ball position)
-    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    const playfield = document.querySelector(INTERACTIVE_PLAYFIELD_SELECTOR);
     if (playfield) {
       await user.click(playfield);
 
@@ -468,7 +469,7 @@ describe('App - Animation Skip Final Position Coverage', () => {
     expect(circles.length).toBeGreaterThan(0);
 
     // Click playfield to continue
-    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    const playfield = document.querySelector(INTERACTIVE_PLAYFIELD_SELECTOR);
     if (playfield) {
       await user.click(playfield);
     }
@@ -492,7 +493,7 @@ describe('App - Animation Skip Final Position Coverage', () => {
     }, { timeout: 2000 });
 
     // Continue
-    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    const playfield = document.querySelector(INTERACTIVE_PLAYFIELD_SELECTOR);
     if (playfield) {
       await user.click(playfield);
     }

--- a/tests/vitest/app-patch-coverage.test.jsx
+++ b/tests/vitest/app-patch-coverage.test.jsx
@@ -1,0 +1,519 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+import App from '../../src/app.jsx';
+
+const PLAYFIELD_SELECTOR = '.relative.border.rounded-xl';
+
+async function setupAndGoToPractice(user) {
+  render(<App />);
+
+  await waitFor(() => {
+    expect(screen.getByText(/setup shots/i)).toBeInTheDocument();
+  });
+
+  const exampleButton = screen.getByRole('button', { name: /load example shots/i });
+  await user.click(exampleButton);
+
+  await waitFor(() => {
+    expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+
+  const practiceButton = screen.getAllByRole('button').find(btn =>
+    btn.textContent === 'Practice' && !btn.disabled,
+  );
+
+  if (practiceButton) {
+    await user.click(practiceButton);
+    await waitFor(() => {
+      expect(screen.queryByText(/setup shots/i)).not.toBeInTheDocument();
+    }, { timeout: 3000 });
+  }
+}
+
+describe('App - Animation and Static Ball Coverage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should exercise animation complete path with final ball position', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make multiple guesses to exercise the animation code path multiple times
+    for (let i = 0; i < 3; i++) {
+      const recallButton = screen.getByRole('button', { name: /recall 50/i });
+      await user.click(recallButton);
+
+      // Wait for awaiting state
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /recall 50/i });
+        expect(btn).toBeDisabled();
+      }, { timeout: 5000 });
+
+      // Wait for animation to fully complete (800ms+ for travel + shake)
+      await new Promise(resolve => setTimeout(resolve, 1200));
+
+      // Click playfield to continue
+      const playfield = document.querySelector(PLAYFIELD_SELECTOR);
+      if (playfield) {
+        await user.click(playfield);
+        await waitFor(() => {
+          const btn = screen.getByRole('button', { name: /recall 50/i });
+          expect(btn).not.toBeDisabled();
+        }, { timeout: 3000 });
+      }
+    }
+  }, 30000);
+
+  it('should exercise shake progress calculation for different error magnitudes', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Test with a guess that will have significant error (high shake)
+    const recallButton85 = screen.getByRole('button', { name: /recall 85/i });
+    await user.click(recallButton85);
+
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /recall 85/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 5000 });
+
+    // Wait for full animation including shake phase
+    await new Promise(resolve => setTimeout(resolve, 1500));
+
+    // Click to continue
+    const playfield = document.querySelector(PLAYFIELD_SELECTOR);
+    if (playfield) {
+      await user.click(playfield);
+    }
+  }, 20000);
+
+  it('should exercise guide line rendering with severity colors', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess to get a result with severity
+    const recallButton = screen.getByRole('button', { name: /recall 75/i });
+    await user.click(recallButton);
+
+    // Wait for awaiting state and animation
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /recall 75/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 5000 });
+
+    // Wait for animation to complete
+    await new Promise(resolve => setTimeout(resolve, 1200));
+
+    // Verify line elements are rendered (guide lines with stroke)
+    const lines = document.querySelectorAll('line');
+    expect(lines.length).toBeGreaterThan(0);
+
+    // Verify polygon elements (shaded wedge)
+    const polygons = document.querySelectorAll('polygon');
+    expect(polygons.length).toBeGreaterThan(0);
+  }, 20000);
+
+  it('should exercise pending shot state in random mode', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Switch to random mode
+    const randomButton = screen.getAllByRole('button').find(btn => btn.textContent === 'Random');
+    if (randomButton) {
+      await user.click(randomButton);
+    }
+
+    // Make several guesses to exercise random pending shot logic
+    for (let i = 0; i < 2; i++) {
+      const recallButton = screen.getByRole('button', { name: /recall 50/i });
+      await user.click(recallButton);
+
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /recall 50/i });
+        expect(btn).toBeDisabled();
+      }, { timeout: 3000 });
+
+      // Wait briefly then continue
+      await new Promise(resolve => setTimeout(resolve, 600));
+
+      const playfield = document.querySelector(PLAYFIELD_SELECTOR);
+      if (playfield) {
+        await user.click(playfield);
+        await waitFor(() => {
+          const btn = screen.getByRole('button', { name: /recall 50/i });
+          expect(btn).not.toBeDisabled();
+        }, { timeout: 3000 });
+      }
+    }
+  }, 25000);
+
+  it('should exercise pending shot state in manual mode', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Ensure manual mode
+    const manualButton = screen.getAllByRole('button').find(btn => btn.textContent === 'Manual');
+    if (manualButton) {
+      await user.click(manualButton);
+    }
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /recall 60/i });
+    await user.click(recallButton);
+
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /recall 60/i });
+      expect(btn).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Continue
+    const playfield = document.querySelector(PLAYFIELD_SELECTOR);
+    if (playfield) {
+      await user.click(playfield);
+    }
+  }, 15000);
+});
+
+describe('App - Playfield Interaction Coverage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should exercise handlePlayfieldClick callback', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess to enter awaiting state
+    const recallButton = screen.getByRole('button', { name: /recall 50/i });
+    await user.click(recallButton);
+
+    await waitFor(() => {
+      expect(recallButton).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Find playfield and click it multiple times to exercise the callback
+    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    if (playfield) {
+      await user.click(playfield);
+
+      await waitFor(() => {
+        expect(recallButton).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 15000);
+
+  it('should exercise keyboard handlers on playfield', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /recall 55/i });
+    await user.click(recallButton);
+
+    await waitFor(() => {
+      expect(recallButton).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Test Enter key
+    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    if (playfield) {
+      playfield.focus();
+      fireEvent.keyDown(playfield, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(recallButton).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 15000);
+
+  it('should exercise Space key handler with preventDefault', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /recall 65/i });
+    await user.click(recallButton);
+
+    await waitFor(() => {
+      expect(recallButton).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Test Space key
+    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    if (playfield) {
+      playfield.focus();
+      fireEvent.keyDown(playfield, { key: ' ' });
+
+      await waitFor(() => {
+        expect(recallButton).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 15000);
+
+  it('should not call onAdvanceToNextShot when not awaiting', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Try clicking playfield when NOT awaiting - nothing should happen
+    const playfield = document.querySelector(PLAYFIELD_SELECTOR);
+    if (playfield) {
+      await user.click(playfield);
+    }
+
+    // Buttons should still be enabled
+    const recallButton = screen.getByRole('button', { name: /recall 50/i });
+    expect(recallButton).not.toBeDisabled();
+  }, 15000);
+});
+
+describe('App - Reset Button Coverage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should exercise reset to defaults button click handler', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/setup shots/i)).toBeInTheDocument();
+    });
+
+    const exampleButton = screen.getByRole('button', { name: /load example shots/i });
+    await user.click(exampleButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+
+    // Find and click Advanced options button
+    const advancedButton = screen.getAllByRole('button').find(btn => {
+      const title = btn.getAttribute('title');
+      return title && title.toLowerCase().includes('advanced');
+    });
+
+    if (advancedButton) {
+      await user.click(advancedButton);
+
+      // Wait for popover content to appear
+      await waitFor(() => {
+        expect(screen.getByText(/reset to defaults/i)).toBeInTheDocument();
+      }, { timeout: 2000 });
+
+      // Click the reset button
+      const resetButton = screen.getByRole('button', { name: /reset to defaults/i });
+      await user.click(resetButton);
+
+      // Verify the button was clicked (it should still be there)
+      expect(resetButton).toBeInTheDocument();
+    }
+  }, 15000);
+});
+
+describe('App - advanceToNextShot Callback Coverage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should return early from advanceToNextShot when not awaiting', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // The advanceToNextShot callback should return early when awaitingNextShot is false
+    // We can test this by attempting to interact with playfield before any guess
+    const playfield = document.querySelector(PLAYFIELD_SELECTOR);
+    
+    // Before making a guess, playfield shouldn't have role=button
+    const interactivePlayfield = document.querySelector('[role="button"][tabindex="0"]');
+    expect(interactivePlayfield).toBeNull();
+
+    // Make a guess to trigger awaiting state
+    const recallButton = screen.getByRole('button', { name: /recall 50/i });
+    await user.click(recallButton);
+
+    // Now playfield should be interactive
+    await waitFor(() => {
+      const interactive = document.querySelector('[role="button"][tabindex="0"]');
+      expect(interactive).not.toBeNull();
+    }, { timeout: 3000 });
+  }, 15000);
+
+  it('should apply pending next shot values when clicking to continue', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Switch to random mode to test pending values
+    const randomButton = screen.getAllByRole('button').find(btn => btn.textContent === 'Random');
+    if (randomButton) {
+      await user.click(randomButton);
+    }
+
+    const recallButton = screen.getByRole('button', { name: /recall 50/i });
+    await user.click(recallButton);
+
+    await waitFor(() => {
+      expect(recallButton).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Click playfield to apply pending values
+    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    if (playfield) {
+      await user.click(playfield);
+
+      // Verify state is cleared
+      await waitFor(() => {
+        expect(recallButton).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 15000);
+});
+
+describe('App - Guide Color and Stroke Coverage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should render neutral guide color before making a guess', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Without making a guess, guide should be neutral slate color
+    const lines = document.querySelectorAll('line');
+    // Guide lines should exist for the selected shot
+    expect(lines.length).toBeGreaterThan(0);
+  }, 15000);
+
+  it('should render severity-colored guide after making a guess', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess with error
+    const recallButton = screen.getByRole('button', { name: /recall 80/i });
+    await user.click(recallButton);
+
+    // Wait for awaiting state
+    await waitFor(() => {
+      expect(recallButton).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Wait for animation and feedback
+    await new Promise(resolve => setTimeout(resolve, 1200));
+
+    // Lines should be rendered with severity color
+    const lines = document.querySelectorAll('line');
+    expect(lines.length).toBeGreaterThan(0);
+  }, 20000);
+});
+
+describe('App - Clear Final Ball Position Coverage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should clear final ball position when awaitingNextShot becomes false', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /recall 50/i });
+    await user.click(recallButton);
+
+    // Wait for awaiting state
+    await waitFor(() => {
+      expect(recallButton).toBeDisabled();
+    }, { timeout: 3000 });
+
+    // Wait for animation to complete (ball position should be saved)
+    await new Promise(resolve => setTimeout(resolve, 1500));
+
+    // Click playfield to clear awaiting state (which should clear final ball position)
+    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    if (playfield) {
+      await user.click(playfield);
+
+      // Wait for state to update
+      await waitFor(() => {
+        expect(recallButton).not.toBeDisabled();
+      }, { timeout: 3000 });
+    }
+  }, 20000);
+});
+
+describe('App - Animation Skip Final Position Coverage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should save final position when skipping with keypress', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /recall 50/i });
+    await user.click(recallButton);
+
+    // Skip immediately with Escape
+    await user.keyboard('{Escape}');
+
+    // Wait for awaiting state
+    await waitFor(() => {
+      expect(recallButton).toBeDisabled();
+    }, { timeout: 2000 });
+
+    // Verify SVG elements exist (ball should be rendered at final position)
+    const circles = document.querySelectorAll('circle');
+    expect(circles.length).toBeGreaterThan(0);
+
+    // Click playfield to continue
+    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    if (playfield) {
+      await user.click(playfield);
+    }
+  }, 15000);
+
+  it('should handle skip during travel phase', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /recall 55/i });
+    await user.click(recallButton);
+
+    // Wait a tiny bit then skip with Enter (during travel phase)
+    await new Promise(resolve => setTimeout(resolve, 200));
+    await user.keyboard('{Enter}');
+
+    // Should be in awaiting state
+    await waitFor(() => {
+      expect(recallButton).toBeDisabled();
+    }, { timeout: 2000 });
+
+    // Continue
+    const playfield = document.querySelector('[role="button"][tabindex="0"]');
+    if (playfield) {
+      await user.click(playfield);
+    }
+  }, 15000);
+
+  it('should handle skip during shake phase', async () => {
+    const user = userEvent.setup();
+    await setupAndGoToPractice(user);
+
+    // Make a guess
+    const recallButton = screen.getByRole('button', { name: /recall 60/i });
+    await user.click(recallButton);
+
+    // Wait for travel to complete then skip during shake (500ms + 100ms)
+    await new Promise(resolve => setTimeout(resolve, 600));
+    await user.keyboard(' ');
+
+    // Should be in awaiting state
+    await waitFor(() => {
+      expect(recallButton).toBeDisabled();
+    }, { timeout: 2000 });
+  }, 15000);
+});

--- a/tests/vitest/app-patch-coverage.test.jsx
+++ b/tests/vitest/app-patch-coverage.test.jsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 
 import App from '../../src/app.jsx';
 

--- a/tests/vitest/app-patch-coverage.test.jsx
+++ b/tests/vitest/app-patch-coverage.test.jsx
@@ -325,7 +325,6 @@ describe('App - advanceToNextShot Callback Coverage', () => {
 
     // The advanceToNextShot callback should return early when awaitingNextShot is false
     // We can test this by attempting to interact with playfield before any guess
-    const playfield = document.querySelector(PLAYFIELD_SELECTOR);
     
     // Before making a guess, playfield shouldn't have role=button
     const interactivePlayfield = document.querySelector('[role="button"][tabindex="0"]');


### PR DESCRIPTION
## Summary
Add click-to-continue flow and improve practice mode UX

## Changes
- Add click-to-continue: user must click playfield to advance to next shot
- Hide feedback (guess value, line, result box) when advancing to next shot
- Change shaded area color to match severity when result is shown
- Use neutral slate gray for initial guide color instead of green
- Improve ball animation smoothness using refs instead of state per frame
- Add DISABLED_CLASS constant to reduce string duplication
- Add keyboard accessibility to playfield click handler
- Update E2E test to handle click-to-continue flow

## Testing
- All 253 unit tests pass
- All 4 E2E tests pass
- Build succeeds