### PR TITLE
feat: add release link to About modal

### DIFF
--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -66,6 +66,7 @@ const config = [
         __BUILD_COMMIT__: 'readonly',
         __BUILD_COMMIT_URL__: 'readonly',
         __BUILD_WORKFLOW_URL__: 'readonly',
+        __RELEASE_URL__: 'readonly',
       },
       parserOptions: {
         ecmaVersion: 'latest',

--- a/config/vite.config.js
+++ b/config/vite.config.js
@@ -77,6 +77,8 @@ export default defineConfig({
     __BUILD_COMMIT_URL__: JSON.stringify(process.env.BUILD_COMMIT_URL || ''),
 
     __BUILD_WORKFLOW_URL__: JSON.stringify(process.env.BUILD_WORKFLOW_URL || ''),
+
+    __RELEASE_URL__: JSON.stringify(process.env.RELEASE_URL || `https://github.com/garybrowndev/PinballAccuracyMemoryTrainer/releases/tag/v${packageJson.version}`),
   },
   build: {
     sourcemap: true,

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -3328,7 +3328,18 @@ const App = () => {
                 </div>
                 <div className="pt-4 border-t text-sm text-slate-500">
                   <p>
-                    Version {typeof __APP_VERSION__ === 'undefined' ? '0.0.1' : __APP_VERSION__}
+                    Version {(() => {
+                      const version = typeof __APP_VERSION__ === 'undefined' ? '0.0.1' : __APP_VERSION__;
+                      const releaseUrl = typeof __RELEASE_URL__ === 'undefined' ? '' : __RELEASE_URL__;
+                      if (releaseUrl) {
+                        return (
+                          <a href={releaseUrl} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline" title="View release notes">
+                            {version}
+                          </a>
+                        );
+                      }
+                      return version;
+                    })()}
                     {(() => {
                       if (typeof __BUILD_COMMIT__ === 'undefined' || !__BUILD_COMMIT__) {
                         return null;


### PR DESCRIPTION
- Add __RELEASE_URL__ define variable to vite config
- Make version number in About modal clickable
- Link directs to GitHub release page for current version