### PR TITLE
Fix dark mode background on page scroll and smart dropdown positioning

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,10 +3,17 @@
 /* Ensure minimum body width to prevent content from being drawn off-screen */
 html {
   scrollbar-gutter: stable;
+  min-height: 100%;
 }
 
 body {
   min-width: 320px;
+  min-height: 100%;
+}
+
+/* Dark mode background for html and body to prevent white flash when page grows */
+html:has(.dark), html:has(.dark) body {
+  background-color: #020617; /* slate-950 - matches the to-slate-950 gradient end */
 }
 
 /* Safe area padding for devices with notches/rounded corners (iOS, modern Android) */


### PR DESCRIPTION
## Summary
- Add dark mode background color to html/body elements to prevent white background showing when page extends (e.g., when dropdowns cause scroll)
- Implement smart dropdown positioning that opens upward when there's not enough space below the trigger button
- Use CSS transform translateY(-100%) for accurate upward positioning regardless of dropdown height
- Apply to shot menu, location menu, and Add Shot(s) dropdown

## Changes
- `src/index.css`: Added dark mode background for html/body
- `src/app.jsx`: Added `calcDropdownAnchor()` helper and updated dropdown positioning logic