### PR TITLE
fix(cd): use APP_VERSION env var for release version display

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -161,6 +161,7 @@ jobs:
         if: steps.check_tag.outputs.exists == 'false'
         run: npm run build:standalone
         env:
+          APP_VERSION: ${{ steps.version.outputs.full_version }}
           BUILD_COMMIT: ${{ steps.version.outputs.commit_hash }}
           BUILD_COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ steps.version.outputs.commit_hash }}
           BUILD_WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/config/vite.config.js
+++ b/config/vite.config.js
@@ -69,7 +69,7 @@ export default defineConfig({
     }),
   ],
   define: {
-    __APP_VERSION__: JSON.stringify(packageJson.version),
+    __APP_VERSION__: JSON.stringify(process.env.APP_VERSION || packageJson.version),
 
     __BUILD_COMMIT__: JSON.stringify(process.env.BUILD_COMMIT || 'dev'),
 


### PR DESCRIPTION
## Changes

- Add `APP_VERSION` environment variable to cd-release workflow build step
- Update vite.config.js to prioritize `APP_VERSION` env var over package.json
- Fixes About page showing hardcoded 0.0.1 instead of calculated version

## Problem

The version displayed in the About page was always showing "0.0.1" because the build process was reading from package.json instead of using the calculated version from the cd-release workflow.

## Solution

Modified the build process to accept an `APP_VERSION` environment variable that gets set to the calculated version (e.g., "0.0.395.20251213.1430") during release builds, while still falling back to package.json for local development.

## Testing

- All unit tests passed (239/239)
- All E2E tests passed (56 passed, 1 skipped)
- Build successful