### PR TITLE
chore: configure dependabot to group all updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,30 +17,9 @@ updates:
     labels:
       - 'dependencies'
     groups:
-      # Group all production dependencies together
-      production-dependencies:
+      all-npm-dependencies:
         patterns:
-          - 'react*'
-          - 'react-dom*'
-      # Group all dev dependencies together
-      dev-dependencies:
-        dependency-type: 'development'
-        update-types:
-          - 'minor'
-          - 'patch'
-      # Group all eslint-related packages
-      eslint:
-        patterns:
-          - 'eslint*'
-          - '@eslint/*'
-      # Group all testing packages
-      testing:
-        patterns:
-          - 'vitest'
-          - '@vitest/*'
-          - '@testing-library/*'
-          - '@playwright/*'
-          - 'playwright'
+          - '*'
 
   # GitHub Actions
   - package-ecosystem: 'github-actions'
@@ -50,6 +29,10 @@ updates:
       day: 'monday'
       time: '09:00'
       timezone: 'America/New_York'
+    groups:
+      all-actions:
+        patterns:
+          - '*'
     open-pull-requests-limit: 5
     commit-message:
       prefix: 'chore(ci)'


### PR DESCRIPTION
- Group all npm dependencies into a single PR
- Group all GitHub Actions updates into a single PR