### PR TITLE
test: verify scorecard baseline fix

### DIFF
--- a/.github/copilot-lessons-learned.md
+++ b/.github/copilot-lessons-learned.md
@@ -57,3 +57,20 @@ This file documents mistakes made by AI assistants during development to prevent
 ---
 
 _Add new entries below as they occur. Keep this file as a living document._
+
+---
+
+## GitHub Code Scanning
+
+### "Configuration Not Found" Stale Category Fix
+
+**Date**: 2025-12-23
+**Mistake**: Assumed the "1 configuration not found" neutral check on PRs was benign or unfixable
+**Correct Approach**: This occurs when a SARIF upload category exists on the base branch (e.g., `supply-chain/branch-protection`) but is not generated for PR branches. The fix is to DELETE all analyses with that stale category using the GitHub API:
+
+```bash
+gh api repos/{owner}/{repo}/code-scanning/analyses/{id}?confirm_delete=true --method DELETE
+```
+
+Each delete returns `next_analysis_url` - continue deleting until you get `null`, fully purging the stale category.
+**Prevention**: When seeing "configuration not found" warnings, compare categories between `refs/heads/master` and `refs/pull/{n}/merge` analyses to identify the mismatch, then delete the stale category from the base branch.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _👆 Click the screenshot to launch the app_
 
 |                                                              |                                                      |
 | :----------------------------------------------------------: | :--------------------------------------------------: |
-|              🎰 **38+ Classic & Modern Tables**              |      🧠 **Memory Training with Dynamic Drift**       |
+|                  🎰 **38+ Classic Tables**                   |      🧠 **Memory Training with Dynamic Drift**       |
 | Addams Family, Medieval Madness, Attack from Mars, and more! | Values shift as you practice — no rote memorization! |
 |            📊 **Real-Time Performance Tracking**             |              🌐 **Works 100% Offline**               |
 |    Instant feedback on accuracy with color-coded results     |       All data stored locally in your browser        |

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The trainer helps pinball players develop muscle memory for shot accuracy by:
 ### Shot Configuration
 
 - **Visual playfield editor** - Arrange shots spatially on an arc-based layout with visual flipper representations
-- **38 pinball preset tables** - Pre-configured shot layouts from classic and modern pinball machines (Addams Family, Medieval Madness, Attack from Mars, etc.)
+- **39 pinball preset tables** - Pre-configured shot layouts from classic and modern pinball machines (Addams Family, Medieval Madness, Attack from Mars, etc.)
 - **Custom shot creation** - Setup shots using 20 base elements (Ramp, Orbit, Drops, Spinner, etc.) combined with 8 location modifiers (Left, Right, Center, Side, Top, Upper, Bottom, Lower)
 - **Image-based tiles** - Optional visual shot element thumbnails with 80×80px tiles (extensible with WebP images in `/public/images/elements/`)
 - **Export/import** - Save your custom shot configurations as JSON files

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The trainer helps pinball players develop muscle memory for shot accuracy by:
 ### Shot Configuration
 
 - **Visual playfield editor** - Arrange shots spatially on an arc-based layout with visual flipper representations
-- **39 pinball preset tables** - Pre-configured shot layouts from classic and modern pinball machines (Addams Family, Medieval Madness, Attack from Mars, etc.)
+- **39 pinball preset tables** - Pre-configured shot layouts from classic pinball machines (Addams Family, Medieval Madness, Attack from Mars, etc.)
 - **Custom shot creation** - Setup shots using 20 base elements (Ramp, Orbit, Drops, Spinner, etc.) combined with 8 location modifiers (Left, Right, Center, Side, Top, Upper, Bottom, Lower)
 - **Image-based tiles** - Optional visual shot element thumbnails with 80×80px tiles (extensible with WebP images in `/public/images/elements/`)
 - **Export/import** - Save your custom shot configurations as JSON files


### PR DESCRIPTION
Testing that the OSSF Scorecard 'configuration not found' neutral check is resolved now that a baseline exists on master.

This PR makes a trivial documentation update (38  39 preset tables) to trigger CI checks.

Expected outcome: No scorecard configuration warning on this PR.