### PR TITLE
fix: disable scorecard publish_results to allow run steps

### DIFF
--- a/.github/workflows/security-ossf-scorecard.yml
+++ b/.github/workflows/security-ossf-scorecard.yml
@@ -58,7 +58,10 @@ jobs:
           # For private repositories:
           #   - `publish_results` will always be set to `false`, regardless
           #     of the value entered here.
-          publish_results: true
+          # NOTE: Publishing disabled because it requires jobs with ONLY `uses:` steps
+          # (no `run:` steps allowed). We need `run:` steps for summaries and PR comments.
+          # See: https://github.com/ossf/scorecard-action#workflow-restrictions
+          publish_results: false
 
       # Note: Branch-Protection check will not run on PRs without admin PAT token.
       # This is expected behavior - the check requires additional permissions beyond


### PR DESCRIPTION
## Problem

The Scorecard workflow was failing with HTTP 400 error:
`
workflow verification failed: scorecard job must only have steps with 'uses'
`

## Root Cause

When publish_results: true is set, the OSSF Scorecard action enforces a strict requirement that the job can ONLY contain steps with uses: - no un: steps are allowed.

Our workflow has two incompatible steps:
1. **Generate job summary** - uses un: to execute Python script
2. **Update PR Comment** - uses ctions/github-script which internally runs JavaScript

## Solution

Set publish_results: false. Publishing to the OSSF REST API is optional and not essential for security checks.

The workflow still provides full functionality:
-  Generates SARIF file with security analysis
-  Uploads artifact for download
-  Uploads to code-scanning dashboard
-  Generates job summaries
-  Updates PR comments
-  Branch-Protection check with admin PAT

## References

- [OSSF Scorecard Workflow Restrictions](https://github.com/ossf/scorecard-action#workflow-restrictions)
- Failed run: https://github.com/garybrowndev/PinballAccuracyMemoryTrainer/actions/runs/20490296286