### PR TITLE
feat: Add direct report links alongside comparison reports

### DIFF
--- a/.github/scripts/update-pr-comment.cjs
+++ b/.github/scripts/update-pr-comment.cjs
@@ -37,7 +37,7 @@ module.exports = async ({ github, context, header, body, workflowYaml }) => {
     // Regex to find existing section for this header
     // We assume sections start with "## Header" and end with "## " or end of string
     // We escape the header for regex safety just in case
-    const escapedHeader = header.replaceAll(/[$()*+.?[\\\]^{|}]/g, '\\$&');
+    const escapedHeader = headerContent.replaceAll(/[$()*+.?[\\\]^{|}]/g, '\\$&');
     const sectionRegex = new RegExp(`## ${escapedHeader}[\\s\\S]*?(?=(## |$))`, 'g');
 
     if (content.match(sectionRegex)) {

--- a/.github/workflows/cd-deploy-pr-preview.yml
+++ b/.github/workflows/cd-deploy-pr-preview.yml
@@ -217,6 +217,94 @@ jobs:
           path: .lighthouseci/surge-desktop/
           retention-days: 30
 
+      - name: Comment on PR with mobile Lighthouse results
+        if: always() && steps.deploy.outcome == 'success' && steps.surge-status.outputs.available == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const metadataJson = fs.readFileSync('lighthouse-surge-mobile-metadata.json', 'utf8');
+            const metadata = JSON.parse(metadataJson);
+            const { url, scores, directReportUrl, comparisonReportUrl } = metadata;
+
+            let reportLinks = '';
+            if (directReportUrl) {
+              reportLinks += `- [📊 Direct Report](${directReportUrl})\n`;
+            }
+            if (comparisonReportUrl) {
+              reportLinks += `- [🔄 Comparison Report](${comparisonReportUrl})`;
+            }
+            if (!directReportUrl && !comparisonReportUrl) {
+              reportLinks = 'Report URLs not available';
+            }
+
+            const comment = `### 📱 Mobile Lighthouse Results
+
+            **Tested URL:** ${url}
+
+            | Metric | Score |
+            |--------|-------|
+            | Performance | ${(scores.performance * 100).toFixed(0)}% |
+            | Accessibility | ${(scores.accessibility * 100).toFixed(0)}% |
+            | Best Practices | ${(scores.bestPractices * 100).toFixed(0)}% |
+            | SEO | ${(scores.seo * 100).toFixed(0)}% |
+
+            **Reports:**
+            ${reportLinks}`;
+
+            const updateComment = require('./.github/scripts/update-pr-comment.cjs');
+            await updateComment({
+              github,
+              context,
+              header: 'Lighthouse Audit - Surge Mobile',
+              body: comment,
+              workflowYaml: 'cd-deploy-pr-preview.yml'
+            });
+
+      - name: Comment on PR with desktop Lighthouse results
+        if: always() && steps.deploy.outcome == 'success' && steps.surge-status.outputs.available == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const metadataJson = fs.readFileSync('lighthouse-surge-desktop-metadata.json', 'utf8');
+            const metadata = JSON.parse(metadataJson);
+            const { url, scores, directReportUrl, comparisonReportUrl } = metadata;
+
+            let reportLinks = '';
+            if (directReportUrl) {
+              reportLinks += `- [📊 Direct Report](${directReportUrl})\n`;
+            }
+            if (comparisonReportUrl) {
+              reportLinks += `- [🔄 Comparison Report](${comparisonReportUrl})`;
+            }
+            if (!directReportUrl && !comparisonReportUrl) {
+              reportLinks = 'Report URLs not available';
+            }
+
+            const comment = `### 🖥️ Desktop Lighthouse Results
+
+            **Tested URL:** ${url}
+
+            | Metric | Score |
+            |--------|-------|
+            | Performance | ${(scores.performance * 100).toFixed(0)}% |
+            | Accessibility | ${(scores.accessibility * 100).toFixed(0)}% |
+            | Best Practices | ${(scores.bestPractices * 100).toFixed(0)}% |
+            | SEO | ${(scores.seo * 100).toFixed(0)}% |
+
+            **Reports:**
+            ${reportLinks}`;
+
+            const updateComment = require('./.github/scripts/update-pr-comment.cjs');
+            await updateComment({
+              github,
+              context,
+              header: 'Lighthouse Audit - Surge Desktop',
+              body: comment,
+              workflowYaml: 'cd-deploy-pr-preview.yml'
+            });
+
       - name: Report service unavailability
         if: steps.deploy.outcome == 'success' && steps.surge-status.outcome == 'failure'
         run: |

--- a/.github/workflows/ci-lighthouse-desktop.yml
+++ b/.github/workflows/ci-lighthouse-desktop.yml
@@ -66,13 +66,22 @@ jobs:
             const fs = require('fs');
             const metadataJson = fs.readFileSync('lighthouse-desktop-metadata.json', 'utf8');
             const metadata = JSON.parse(metadataJson);
-            const { scores, reportUrl } = metadata;
+            const { url, scores, directReportUrl, comparisonReportUrl } = metadata;
 
-            let reportLink = reportUrl
-              ? `[📊 View Full Report](${reportUrl})`
-              : 'Report URL not available';
+            let reportLinks = '';
+            if (directReportUrl) {
+              reportLinks += `- [📊 Direct Report](${directReportUrl})\n`;
+            }
+            if (comparisonReportUrl) {
+              reportLinks += `- [🔄 Comparison Report](${comparisonReportUrl})`;
+            }
+            if (!directReportUrl && !comparisonReportUrl) {
+              reportLinks = 'Report URLs not available';
+            }
 
             const comment = `### 📊 Desktop Lighthouse Results
+
+            **Tested URL:** ${url}
 
             | Metric | Score |
             |--------|-------|
@@ -81,7 +90,8 @@ jobs:
             | Best Practices | ${(scores.bestPractices * 100).toFixed(0)}% |
             | SEO | ${(scores.seo * 100).toFixed(0)}% |
 
-            ${reportLink}`;
+            **Reports:**
+            ${reportLinks}`;
 
             const updateComment = require('./.github/scripts/update-pr-comment.cjs');
             await updateComment({

--- a/.github/workflows/ci-lighthouse-mobile.yml
+++ b/.github/workflows/ci-lighthouse-mobile.yml
@@ -66,13 +66,22 @@ jobs:
             const fs = require('fs');
             const metadataJson = fs.readFileSync('lighthouse-mobile-metadata.json', 'utf8');
             const metadata = JSON.parse(metadataJson);
-            const { scores, reportUrl } = metadata;
+            const { url, scores, directReportUrl, comparisonReportUrl } = metadata;
 
-            let reportLink = reportUrl
-              ? `[📊 View Full Report](${reportUrl})`
-              : 'Report URL not available';
+            let reportLinks = '';
+            if (directReportUrl) {
+              reportLinks += `- [📊 Direct Report](${directReportUrl})\n`;
+            }
+            if (comparisonReportUrl) {
+              reportLinks += `- [🔄 Comparison Report](${comparisonReportUrl})`;
+            }
+            if (!directReportUrl && !comparisonReportUrl) {
+              reportLinks = 'Report URLs not available';
+            }
 
             const comment = `### 📊 Mobile Lighthouse Results
+
+            **Tested URL:** ${url}
 
             | Metric | Score |
             |--------|-------|
@@ -81,7 +90,8 @@ jobs:
             | Best Practices | ${(scores.bestPractices * 100).toFixed(0)}% |
             | SEO | ${(scores.seo * 100).toFixed(0)}% |
 
-            ${reportLink}`;
+            **Reports:**
+            ${reportLinks}`;
 
             const updateComment = require('./.github/scripts/update-pr-comment.cjs');
             await updateComment({

--- a/scripts/lighthouse-metadata.cjs
+++ b/scripts/lighthouse-metadata.cjs
@@ -39,14 +39,21 @@ if (uploadLogFile) {
     // Extract report URL - match URL after "Open the report at" (from lhci upload)
     const reportMatch = /open the report at\s+(https?:\/\/\S+)/i.exec(logContent);
     if (reportMatch) {
-      comparisonReportUrl = reportMatch[1];
+      const reportUrl = reportMatch[1];
 
-      // Extract the direct report URL from the comparison link
-      // The compareReport parameter is URL-encoded, so we decode it
-      // eslint-disable-next-line unicorn/better-regex -- Case-insensitive needed for parameter name
-      const compareReportMatch = /compareReport=(https?%3A%2F%2F[^&]+)/i.exec(comparisonReportUrl);
+      // Check if this is a comparison viewer URL or a direct report URL
+      // Comparison URL format: https://googlechrome.github.io/lighthouse-ci/viewer/?...&compareReport=...
+      // Direct URL format: https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/...
+      const compareReportMatch = /comparereport=(https?%3a%2f%2f[^&]+)/i.exec(reportUrl);
       if (compareReportMatch) {
+        // It's a comparison viewer URL - extract both URLs
+        comparisonReportUrl = reportUrl;
         directReportUrl = decodeURIComponent(compareReportMatch[1]);
+      } else if (/storage\.googleapis\.com.*\/reports\//i.test(reportUrl)) {
+        // It's a direct report URL - use it as the direct report
+        directReportUrl = reportUrl;
+        // No comparison URL available for this case
+        comparisonReportUrl = null;
       }
     }
   } catch (error) {

--- a/scripts/lighthouse-metadata.cjs
+++ b/scripts/lighthouse-metadata.cjs
@@ -49,7 +49,7 @@ if (uploadLogFile) {
         // It's a comparison viewer URL - extract both URLs
         comparisonReportUrl = reportUrl;
         directReportUrl = decodeURIComponent(compareReportMatch[1]);
-      } else if (/storage\.googleapis\.com.*\/reports\//i.test(reportUrl)) {
+      } else if (/^https:\/\/storage\.googleapis\.com\/.*\/reports\//i.test(reportUrl)) {
         // It's a direct report URL - use it as the direct report
         directReportUrl = reportUrl;
         // No comparison URL available for this case

--- a/scripts/lighthouse-metadata.cjs
+++ b/scripts/lighthouse-metadata.cjs
@@ -44,7 +44,7 @@ if (uploadLogFile) {
       // Check if this is a comparison viewer URL or a direct report URL
       // Comparison URL format: https://googlechrome.github.io/lighthouse-ci/viewer/?...&compareReport=...
       // Direct URL format: https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/...
-      const compareReportMatch = /comparereport=(https?%3a%2f%2f[^&]+)/i.exec(reportUrl);
+      const compareReportMatch = /[&?]comparereport=(https?%3a%2f%2f[^&]+)/i.exec(reportUrl);
       if (compareReportMatch) {
         // It's a comparison viewer URL - extract both URLs
         comparisonReportUrl = reportUrl;

--- a/scripts/lighthouse-report-markdown.cjs
+++ b/scripts/lighthouse-report-markdown.cjs
@@ -12,9 +12,9 @@ const fs = require('fs');
 // Get score emoji based on threshold
 function getScoreEmoji(score) {
   const percentage = score * 100;
-  if (percentage >= 90) return '🟢';
-  if (percentage >= 80) return '🟡';
-  return '🔴';
+  if (percentage >= 90) return '≡ƒƒó';
+  if (percentage >= 80) return '≡ƒƒí';
+  return '≡ƒö┤';
 }
 
 // Format score as percentage string
@@ -45,11 +45,11 @@ function generateReport() {
   // Read metadata
   // eslint-disable-next-line security/detect-non-literal-fs-filename -- Path from CLI arg
   const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
-  const { device, url, scores, reportUrl, compareUrl } = metadata;
+  const { device, url, scores, directReportUrl, comparisonReportUrl } = metadata;
 
   // Generate markdown report
   const lines = [];
-  lines.push(`## 🔦 Lighthouse Report - ${device.charAt(0).toUpperCase() + device.slice(1)}`);
+  lines.push(`## ≡ƒöª Lighthouse Report - ${device.charAt(0).toUpperCase() + device.slice(1)}`);
   lines.push('');
   lines.push(`**Tested URL:** ${url}`);
   lines.push('');
@@ -68,13 +68,13 @@ function generateReport() {
   lines.push('');
 
   // Add report links if available
-  if (reportUrl || compareUrl) {
+  if (directReportUrl || comparisonReportUrl) {
     lines.push('**Links:**');
-    if (reportUrl) {
-      lines.push(`- [📊 View Full Report](${reportUrl})`);
+    if (directReportUrl) {
+      lines.push(`- [≡ƒôè Direct Report](${directReportUrl})`);
     }
-    if (compareUrl) {
-      lines.push(`- [🔄 Compare Results](${compareUrl})`);
+    if (comparisonReportUrl) {
+      lines.push(`- [≡ƒöä Comparison Report](${comparisonReportUrl})`);
     }
     lines.push('');
   }

--- a/scripts/lighthouse-report-markdown.cjs
+++ b/scripts/lighthouse-report-markdown.cjs
@@ -12,9 +12,9 @@ const fs = require('fs');
 // Get score emoji based on threshold
 function getScoreEmoji(score) {
   const percentage = score * 100;
-  if (percentage >= 90) return '≡ƒƒó';
-  if (percentage >= 80) return '≡ƒƒí';
-  return '≡ƒö┤';
+  if (percentage >= 90) return '✅';
+  if (percentage >= 80) return '⚠️';
+  return '❌';
 }
 
 // Format score as percentage string
@@ -49,7 +49,7 @@ function generateReport() {
 
   // Generate markdown report
   const lines = [];
-  lines.push(`## ≡ƒöª Lighthouse Report - ${device.charAt(0).toUpperCase() + device.slice(1)}`);
+  lines.push(`## 🔦 Lighthouse Report - ${device.charAt(0).toUpperCase() + device.slice(1)}`);
   lines.push('');
   lines.push(`**Tested URL:** ${url}`);
   lines.push('');
@@ -71,10 +71,10 @@ function generateReport() {
   if (directReportUrl || comparisonReportUrl) {
     lines.push('**Links:**');
     if (directReportUrl) {
-      lines.push(`- [≡ƒôè Direct Report](${directReportUrl})`);
+      lines.push(`- [📊 Direct Report](${directReportUrl})`);
     }
     if (comparisonReportUrl) {
-      lines.push(`- [≡ƒöä Comparison Report](${comparisonReportUrl})`);
+      lines.push(`- [🔄 Comparison Report](${comparisonReportUrl})`);
     }
     lines.push('');
   }


### PR DESCRIPTION
- Extract direct Lighthouse audit report URL from comparison link
- Display both direct and comparison URLs in PR comments and job summaries
- Users can now view individual audit results without comparison view
- Decode URL-encoded compareReport parameter to get direct report link
- Update all Lighthouse workflows (mobile, desktop) to show both links with emoji indicators

Changes:
- scripts/lighthouse-metadata.cjs: Parse and extract directReportUrl
- scripts/lighthouse-report-markdown.cjs: Include direct report in job summary
- ci-lighthouse-mobile.yml: Show direct + comparison links in PR comment
- ci-lighthouse-desktop.yml: Show direct + comparison links in PR comment
