### PR TITLE
fix: add explicit permissions to workflows for Token-Permissions security issues

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -21,6 +21,7 @@ jobs:
       contents: write
       security-events: write
       statuses: write
+      actions: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci-lighthouse-desktop.yml
+++ b/.github/workflows/ci-lighthouse-desktop.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
       - master
+
+permissions:
+  contents: read
+
 concurrency:
   group: lighthouse-desktop-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -15,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      contents: read
       statuses: write
       pull-requests: write
     env:

--- a/.github/workflows/ci-lighthouse-mobile.yml
+++ b/.github/workflows/ci-lighthouse-mobile.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
       - master
+
+permissions:
+  contents: read
+
 concurrency:
   group: lighthouse-mobile-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -15,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      contents: read
       statuses: write
       pull-requests: write
     env:

--- a/.github/workflows/ci-visual-regression-tests.yml
+++ b/.github/workflows/ci-visual-regression-tests.yml
@@ -24,7 +24,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      actions: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci-visual-regression-tests.yml
+++ b/.github/workflows/ci-visual-regression-tests.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: read
 
     steps:
       - name: Checkout code

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,7 @@
+# Map all author identities to canonical identity
+# Format: Canonical Name <canonical@email.com> <old@email.com>
+
+Gary Brown <garybrowndev@gmail.com> <gary.brown@bplogix.com>
+Gary Brown <garybrowndev@gmail.com> <GaryBrownDev@gmail.com>
+Gary Brown <garybrowndev@gmail.com> <garybrowndev@users.noreply.github.com>
+Gary Brown <garybrowndev@gmail.com> Gary Brown <>


### PR DESCRIPTION
##  Security Fix: Token-Permissions Issues

Resolves 7 OSSF Scorecard Token-Permissions security alerts by adding explicit least-privilege permissions to GitHub Actions workflows.

##  Issues Fixed

- Fixes #178 - Token-Permissions in ci-lighthouse-mobile.yml:1
- Fixes #177 - Token-Permissions in ci-lighthouse-desktop.yml:1  
- Fixes #176 - Token-Permissions in ci-lighthouse-mobile.yml:18
- Fixes #175 - Token-Permissions in ci-lighthouse-desktop.yml:18
- Fixes #171 - Token-Permissions in ci-visual-regression-tests.yml:25
- Fixes #169 - Token-Permissions in cd-release.yml:23
- Fixes #168 - Token-Permissions in cd-release.yml:22

##  Changes

### Lighthouse Workflows
-  Added top-level \permissions: contents: read\ declaration
-  Added explicit \contents: read\ to job-level permissions
- Files: \ci-lighthouse-mobile.yml\, \ci-lighthouse-desktop.yml\

### Visual Regression & Release Workflows  
-  Added explicit \ctions: read\ to job-level permissions
- Files: \ci-visual-regression-tests.yml\, \cd-release.yml\

##  Impact

- **Security**: Enforces principle of least privilege for GitHub Actions
- **Compliance**: Satisfies OSSF Scorecard Token-Permissions requirements
- **Behavior**: No functional changes - workflows operate identically with explicit permissions

##  Verification

All workflows now explicitly declare minimal required permissions instead of relying on default permissions.

---

**Related**: [OSSF Scorecard Best Practices](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)