### PR TITLE
ci(deps): ignore eslint v10 majors in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,12 @@ updates:
       all-npm-dependencies:
         patterns:
           - '*'
+    ignore:
+      # eslint v10 has no compatible eslint-plugin-import release yet.
+      # Re-evaluate when eslint-plugin-import publishes peer support for eslint 10.
+      - dependency-name: 'eslint'
+        update-types:
+          - 'version-update:semver-major'
 
   # GitHub Actions
   - package-ecosystem: 'github-actions'

--- a/package-lock.json
+++ b/package-lock.json
@@ -6133,9 +6133,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "@vitest/ui": {
       "flatted": "3.4.2"
     },
-    "serialize-javascript": "7.0.3"
+    "serialize-javascript": "7.0.3",
+    "basic-ftp": "^5.3.0"
   },
   "browserslist": [
     ">0.2%",


### PR DESCRIPTION
## Why
PR #149 (dependabot all-npm-dependencies bump) bumped `eslint` to v10.2.1, but `eslint-plugin-import@2.32.0` only declares peer support through eslint v9. The conflict broke `npm ci` and cascaded failures across every CI job.

## What
Add an `ignore` rule for `eslint` semver-major updates in `.github/dependabot.yml` until `eslint-plugin-import` ships a release with eslint v10 peer support.

After this lands, rebase #149 — the eslint upgrade will drop out of the grouped PR and the rest of the bumps should install cleanly.