### PR TITLE
ci(deps): also ignore @eslint/* v10 majors in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,9 +21,13 @@ updates:
         patterns:
           - '*'
     ignore:
-      # eslint v10 has no compatible eslint-plugin-import release yet.
-      # Re-evaluate when eslint-plugin-import publishes peer support for eslint 10.
+      # Hold the entire eslint ecosystem at v9.x until eslint-plugin-import
+      # ships a release with eslint v10 peer support. @eslint/js v10 declares
+      # peerOptional eslint@^10.0.0, which would force eslint to v10 too.
       - dependency-name: 'eslint'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@eslint/*'
         update-types:
           - 'version-update:semver-major'
 


### PR DESCRIPTION
## Why
Even with `eslint` v10 ignored, dependabot's regenerated PR (#154) still bumped `@eslint/js` to v10. `@eslint/js@10` declares `peerOptional eslint@^10.0.0`, which conflicts with eslint pinned at v9 and breaks `npm ci` again.

## What
Extend the ignore in `.github/dependabot.yml` to cover the whole `@eslint/*` org for semver-majors, keeping the ecosystem coherent at v9.x.

After this lands: rebase #154; `@eslint/js` will drop out of the bump and CI should pass.