### PR TITLE
ci(deps): also ignore @vitejs/plugin-react v6 majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,7 +41,12 @@ updates:
           - 'version-update:semver-major'
       # vite-plugin-pwa@1.2.0 (latest) caps peer at vite ^7.
       # Hold vite at v7 until vite-plugin-pwa ships vite 8 support.
+      # @vitejs/plugin-react v6 declares peer vite@^8 and is also
+      # blocked by the same ceiling — drop both holds together.
       - dependency-name: 'vite'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@vitejs/plugin-react'
         update-types:
           - 'version-update:semver-major'
 


### PR DESCRIPTION
## Why
PR #159 (`@vitejs/plugin-react` 5.2.0 → 6.0.1) cannot land — `@vitejs/plugin-react@6` declares `peer vite@^8`, but vite is held at v7 because `vite-plugin-pwa@1.2.0` (latest) caps its peer at vite ^7. Same root constraint as the existing vite v8 hold.

Without an explicit ignore, dependabot will keep reopening this PR weekly.

## What
Add `@vitejs/plugin-react` to the dependabot ignore list, grouped with `vite` so both holds drop together when vite-plugin-pwa ships vite 8 support.

After this lands, close #159.