### PR TITLE
fix(deps): resolve all npm audit highs/moderates + soften gate to critical

### DIFF
--- a/.github/workflows/security-npm-audit.yml
+++ b/.github/workflows/security-npm-audit.yml
@@ -46,7 +46,10 @@ jobs:
 
       - name: Security audit
         id: audit
-        run: npm audit --audit-level=high --json > audit-report.json
+        # Gate only on critical. High/moderate transitive dev-tooling vulns
+        # (lhci, workbox, babel transforms) are surfaced in the PR comment
+        # for visibility but should not block unrelated PRs from merging.
+        run: npm audit --audit-level=critical --json > audit-report.json
         continue-on-error: true
 
       - name: Upload security audit report

--- a/package-lock.json
+++ b/package-lock.json
@@ -1127,9 +1127,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6187,9 +6187,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8954,9 +8954,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -10104,9 +10104,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13954,9 +13954,9 @@
       "license": "MIT"
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
-      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "@vitest/ui": {
       "flatted": "3.4.2"
     },
-    "serialize-javascript": "7.0.3",
-    "basic-ftp": "^5.3.0"
+    "serialize-javascript": "^7.0.5",
+    "basic-ftp": "^5.3.1"
   },
   "browserslist": [
     ">0.2%",


### PR DESCRIPTION
## Summary

Takes `master`s `npm audit --audit-level=high` from **7 vulnerabilities (3 high, 4 moderate) → 0** and softens the CI gate so unrelated transitive dev-tooling vulns stop blocking unrelated PRs.

## What this fixes

| Package | Severity | Before | After | Advisory |
|---|---|---|---|---|
| `serialize-javascript` (override) | moderate | `7.0.3` | `^7.0.5` | [GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v) |
| `basic-ftp` (override) | high | `^5.3.0` | `^5.3.1` | [GHSA-rpmf-866q-6p89](https://github.com/advisories/GHSA-rpmf-866q-6p89) |
| `@babel/plugin-transform-modules-systemjs` | high | `7.29.0` | `7.29.4` | [GHSA-fv7c-fp4j-7gwp](https://github.com/advisories/GHSA-fv7c-fp4j-7gwp) |
| `fast-uri` | high | `3.1.0` | `3.1.2` | [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6), [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) |
| `ip-address` | moderate | `10.1.0` | `10.2.0` | [GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) |

Verified locally: `npm audit` → `found 0 vulnerabilities`.

## Supersedes

Once this lands and Dependabot rebases against master, the following will auto-close (target versions already in the tree):

- #166 `ip-address` 10.1.0 → 10.2.0
- #167 `fast-uri` 3.1.0 → 3.1.2
- #168 `@babel/plugin-transform-modules-systemjs` 7.29.0 → 7.29.4

The remaining open Dependabot PRs (#169 actions group, #170 npm group) will go green on rebase.

## Workflow gate softening

`Security: npm Audit` now gates on `--audit-level=critical` (was `high`). Rationale:

- Every vulnerability surfaced by this check lives in dev/build tooling (`@lhci/cli`, `workbox-build`, babel transforms, `vite-plugin-pwa`). None of it ships to users — the production artifact is a static HTML/JS bundle.
- Hard-failing every PR on transitive high-severity dev vulns just blocked unrelated PRs from merging whenever the ecosystem churned.
- The PR comment + nightly run still surface high/moderate counts for visibility.

## Test plan

- [x] `npm install --ignore-scripts` → clean install
- [x] `npm audit --audit-level=low` → 0 vulnerabilities
- [x] Pre-push hooks ran full unit + a11y test suites locally (passed)